### PR TITLE
Refactor parser and stdlib into modular packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ psyduck show hello/main.psy           # print resource config
 ```
 
 Flags go *before* the file argument, not after — `psyduck list hello/main.psy
---stat` silently drops `--stat` instead of erroring (Go's flag parsing stops
-looking for flags at the first non-flag argument, and the file is that first
-argument). This is a real sharp edge, not just a style preference.
+--stat` errors with `unrecognized flag "--stat"` rather than running. Go's
+flag parsing stops looking for flags at the first non-flag argument, so
+anything flag-shaped typed after the file never reaches the flag parser at
+all; psyduck checks for that explicitly and rejects it instead of silently
+ignoring it.
 
 ### Using an external plugin
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,15 @@ no external plugins — it's what writes the `.lock` file `run` reads.
 ### 3. Explore
 
 ```sh
-psyduck list hello/main.psy          # list pipelines declared in the file
-psyduck list hello/main.psy --stat   # + resource counts
-psyduck show hello/main.psy          # print resource config
+psyduck list hello/main.psy           # list pipelines declared in the file
+psyduck list --stat hello/main.psy    # + resource counts
+psyduck show hello/main.psy           # print resource config
 ```
+
+Flags go *before* the file argument, not after — `psyduck list hello/main.psy
+--stat` silently drops `--stat` instead of erroring (Go's flag parsing stops
+looking for flags at the first non-flag argument, and the file is that first
+argument). This is a real sharp edge, not just a style preference.
 
 ### Using an external plugin
 
@@ -117,6 +122,19 @@ locked, `run` fails with a clear error rather than loading something
 unexpected. `<name>.lock` is meant to be committed alongside `<name>.psy`;
 `.psyduck/` (the binaries themselves) is not.
 
+**`init` is always safe to re-run** — it always re-fetches, re-builds, and
+rewrites the lock from scratch, so it's also how you recover from a
+corrupted or partially-deleted `.psyduck/` store. Re-run it whenever:
+
+- you add, remove, or edit a `plugin {}` block (directly, or in a file you
+  `import`),
+- you change a plugin's `tag`, or
+- a plugin has no `tag` and you want to pick up whatever's new on its
+  default branch — `init` records the exact ref it resolved (a branch, a
+  tag, or a commit SHA) in the lock file's `ref` field, so you can always
+  tell what a given `.lock` was actually built from, even without `tag`
+  pinned.
+
 ## CLI
 
 ```
@@ -126,9 +144,9 @@ psyduck <command> <file>.psy [args]
 | Command | Purpose |
 |---|---|
 | `run <file>` | Build and run every pipeline declared directly in the file (concurrently, if there's more than one). |
-| `list <file> [--stat]` | List the file's pipelines by name. `--stat` adds `r<producers> x<transformers> c<consumers>` and an `r` flag when `produce-from` is used. |
+| `list [--stat] <file>` | List the file's pipelines by name. `--stat` adds `r<producers> x<transformers> c<consumers>` and an `r` flag when `produce-from` is used. |
 | `show <file> [name ...]` | Print resource references and evaluated config for each pipeline. |
-| `init <file>` | Fetch and compile every `plugin {}` reachable from the file (including through imports), and write `<file>.lock`. Required before `run`/`list`/`show` will work. |
+| `init <file>` | Fetch and compile every `plugin {}` reachable from the file (including through imports), content-address the built binaries into `.psyduck/`, and write `<file>.lock`. Required before `run`/`list`/`show` will work — see [above](#using-an-external-plugin). |
 
 Set `PSYDUCK_LOG_LEVEL` to `trace`/`debug`/`warn`/`error`/`fatal`/`panic` to
 change runtime log verbosity.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ extended with Go plugins that are cloned and compiled on demand.
 - **Configure it**: producers → transformers → consumers, wired declaratively.
 - **Extend it**: any `sdk.Plugin` can be published as a Git repo and referenced
   from a pipeline with a `plugin {}` block.
-- **Run it**: `psyduck run <pipeline-name>`.
+- **Run it**: `psyduck run <file>.psy`.
 
 ## Install
 
@@ -26,9 +26,10 @@ against the same psyduck commit.
 
 ## Getting started
 
-A pipeline workspace is a directory of `.psy` files. All files in the directory
-parse together: resources declared in one file can be referenced from any
-other. Each pipeline is run by name.
+Each `.psy` file is its own unit of configuration — resources and locals
+declared in one file are only visible in that file. To reuse something from
+another file, `import` it explicitly (see [`docs/hcl.md`](docs/hcl.md)).
+Every command that operates on a pipeline takes the file directly.
 
 ### 1. Write a pipeline
 
@@ -59,23 +60,28 @@ pipeline "hello" {
 ```
 
 This uses only stdlib resources (`sequence`, `render`, `file`) — no plugin
-fetch step is needed.
+fetch step is needed, but every file still needs an `init` before it can run
+(see below).
 
-### 2. Run it
+### 2. Init, then run it
 
 ```sh
-psyduck --chdir hello run hello
+psyduck init hello/main.psy    # writes hello/main.lock
+psyduck run hello/main.psy
 # hello #1
 # hello #2
 # hello #3
 ```
 
+`init` is required before `run` for every file, even one like this that uses
+no external plugins — it's what writes the `.lock` file `run` reads.
+
 ### 3. Explore
 
 ```sh
-psyduck --chdir hello list          # list pipelines by name
-psyduck --chdir hello list --stat   # + resource counts
-psyduck --chdir hello show hello    # print resource config
+psyduck list hello/main.psy          # list pipelines declared in the file
+psyduck list hello/main.psy --stat   # + resource counts
+psyduck show hello/main.psy          # print resource config
 ```
 
 ### Using an external plugin
@@ -94,33 +100,38 @@ produce "amqp-queue" "in" {
 }
 ```
 
-Then run once to clone + compile the plugin into `.psyduck/plugins/`:
+Then init the file — this clones + compiles the plugin, content-addresses the
+built binary into `.psyduck/plugins/` (next to the file, keyed by a hash of
+its own bytes), and writes the result to `path/to/<name>.lock`:
 
 ```sh
-psyduck --chdir . init
-psyduck --chdir . run <pipeline-name>
+psyduck init path/to/pipeline.psy
+psyduck run path/to/pipeline.psy
 ```
 
-`init` reads plugin declarations in a cheap pre-pass, so it works before any
-plugin is available. Its output — the manifest at `.psyduck/plugin.json` and
-the `.so` binaries — is loaded automatically on the next `run`.
+`init` reads plugin declarations (following any `import{}`s) in a cheap
+pre-pass, so it works before any plugin is available. `run` reads the lock
+file it wrote, re-verifying each plugin binary's hash before loading it —
+if the store is missing a binary, or its content no longer matches what was
+locked, `run` fails with a clear error rather than loading something
+unexpected. `<name>.lock` is meant to be committed alongside `<name>.psy`;
+`.psyduck/` (the binaries themselves) is not.
 
 ## CLI
 
 ```
-psyduck [--chdir DIR] <command> [args]
+psyduck <command> <file>.psy [args]
 ```
 
 | Command | Purpose |
 |---|---|
-| `run <name>` | Build and run a pipeline. |
-| `list [--stat]` | List pipelines by name. `--stat` adds `r<producers> x<transformers> c<consumers>` and an `r` flag when `produce-from` is used. |
-| `show [name ...]` | Print resource references and evaluated config for each pipeline. |
-| `init` | Fetch and compile every `plugin {}` declared in the workspace. |
+| `run <file>` | Build and run every pipeline declared directly in the file (concurrently, if there's more than one). |
+| `list <file> [--stat]` | List the file's pipelines by name. `--stat` adds `r<producers> x<transformers> c<consumers>` and an `r` flag when `produce-from` is used. |
+| `show <file> [name ...]` | Print resource references and evaluated config for each pipeline. |
+| `init <file>` | Fetch and compile every `plugin {}` reachable from the file (including through imports), and write `<file>.lock`. Required before `run`/`list`/`show` will work. |
 
-`--chdir` selects the workspace directory (default `.`). Set
-`PSYDUCK_LOG_LEVEL` to `trace`/`debug`/`warn`/`error`/`fatal`/`panic` to change
-runtime log verbosity.
+Set `PSYDUCK_LOG_LEVEL` to `trace`/`debug`/`warn`/`error`/`fatal`/`panic` to
+change runtime log verbosity.
 
 ## Docs
 
@@ -133,18 +144,17 @@ runtime log verbosity.
 - [`docs/plugins.md`](docs/plugins.md) — writing plugins in Go: the
   `sdk.Plugin` interface, `Spec` fields, `psy` struct tags, and how psyduck
   loads binaries.
-- [`examples/`](examples/) — one workspace of `.psy` fixtures exercised by the
-  test suite. `shared.psy` holds the consumers reused across examples; each
-  `examples/<name>.psy` defines one pipeline demonstrating a specific stdlib
-  feature.
+- [`examples/`](examples/) — `.psy` fixtures exercised by the test suite, one
+  file per example. `shared.psy` holds consumers reused across the others;
+  files that want them declare their own `import { shared = "shared.psy" }`.
 
 ## Layout
 
 | Package | Purpose |
 |---|---|
 | `github.com/psyduck-etl/sdk` | Format-agnostic plugin SDK (`Plugin`, `Resource`, `Spec`, `Instance`). |
-| `parse` | `Parser`, `Pipeline`, `Resource`, `Source` — format-agnostic pipeline descriptions. |
-| `parse/hcl` | HCL/.psy implementation of `parse.Parser`. |
-| `plugins` | `Store` — clones, builds, and loads external plugins into `.psyduck/`. |
+| `parse` | `Parser`, `Pipeline`, `Resource`, `Source`, `Loader` — format-agnostic pipeline descriptions and file resolution. |
+| `parse/hcl` | HCL/.psy implementation of `parse.Parser`, including `import{}` resolution. |
+| `plugins` | `Store` — clones, builds, and content-addresses external plugins into `.psyduck/`; `Lock`/`ReadLock`/`WriteLock` for the per-file `.lock` format. |
 | `stdlib` | The built-in plugin. Always loaded; no `plugin {}` block needed. |
 | `core` | `BuildPipeline`, `RunPipeline` — turns a parsed pipeline into a running one. |

--- a/docs/hcl.md
+++ b/docs/hcl.md
@@ -7,14 +7,20 @@ reference for the language. It focuses on the stdlib — for plugins, see
 [stdlib.md](stdlib.md); for idiomatic patterns and recipes, see
 [patterns.md](patterns.md).
 
-A **workspace** is any directory containing `.psy` files. All `.psy` files in
-that directory parse together as a single configuration — resources declared
-in one file may be referenced from any other. Each pipeline can be run
-independently by name:
+**A `.psy` file is the unit of configuration.** Resources, locals, and
+plugins declared in one file are visible only within that file — there's no
+implicit directory-wide sharing. To reuse something declared in another
+file, `import` it explicitly (see [Imports](#imports) below).
+
+A file is run by pointing the CLI at it directly:
 
 ```sh
-psyduck --chdir path/to/workspace run <pipeline-name>
+psyduck --chdir path/to/workspace run <file>.psy
 ```
+
+Every `pipeline{}` block declared *directly* in that file runs: a file with
+none is an error, one runs by itself, and more than one run concurrently in
+the same process (see [Running a file](#running-a-file)).
 
 ## Top-level blocks
 
@@ -23,6 +29,7 @@ A `.psy` file contains any number of these blocks, in any order:
 ```hcl
 locals    { ... }                        # named constant values
 plugin    "name" { ... }                 # external plugin declaration (see plugins.md)
+import    { ... }                        # reuse resources/pipelines from another file
 produce   "resource" "name" { ... }      # producer binding
 consume   "resource" "name" { ... }      # consumer binding
 transform "resource" "name" { ... }      # transformer binding
@@ -61,8 +68,8 @@ Two **meta attributes** are host-owned and accepted on every resource block
 | `stop-after` | int | stop this resource after n items (0 = unrestricted) |
 | `per-minute` | int | rate limit, items per minute (0 = unrestricted) |
 
-Declaring the same `(verb, resource, name)` triple twice anywhere in the
-workspace is an error.
+Declaring the same `(verb, resource, name)` triple twice in the same file is
+an error.
 
 ## Pipelines
 
@@ -84,7 +91,7 @@ pipeline "hello" {
 | `exit-on-error` | bool | stop the pipeline on the first error |
 
 Exactly one of `produce` / `produce-from` describes the producer set.
-Pipeline names must be unique across the workspace.
+Pipeline names must be unique within the file.
 
 Data flows: every producer's messages are merged (fan-in), passed through
 the transformer stack in order, and each resulting message is delivered to
@@ -101,9 +108,10 @@ produce = [constant.greeting]           # short form — verb inferred from the 
 ```
 
 The visible refs are scoped by attribute: `produce` only sees producer
-bindings, `consume` only consumers, and so on. `local.*` and `env.*` remain
-available; a resource name that collides with a reserved namespace
-(`local`, `env`) is an error.
+bindings, `consume` only consumers, and so on. `local.*`, `env.*`, and
+`imports.*` remain available in every attribute; a resource name that
+collides with a reserved namespace (`local`, `env`, `imports`) is an
+error.
 
 ### Fan shapes
 
@@ -125,9 +133,10 @@ pipeline "many-to-many" { produce = [produce.constant.1, produce.constant.2]   c
 ## `locals {}` and `env.*`
 
 `locals` declares named constant values, terraform-style. All `locals`
-blocks across all files in the workspace are merged; duplicate names are an
-error. Values are referenced as `local.<name>` and may themselves use
-`env.*`:
+blocks within one file are merged; duplicate names are an error. `locals`
+are file-scoped — a file never sees another file's `local.*` values, even
+one it imports. Values are referenced as `local.<name>` and may themselves
+use `env.*`:
 
 ```hcl
 locals {
@@ -175,6 +184,77 @@ run as if they had been declared literally.
 The seed can be any producer, so the config may come from anywhere a
 producer can read: a file, a socket, an HTTP response — anything the stdlib
 or a plugin exposes.
+
+## Imports
+
+A file reuses another file's resources or pipelines through `import`:
+
+```hcl
+import {
+  shared = "shared.psy"          # relative to this file's own directory
+  lib    = "${env.LIB_DIR}/lib.psy"
+}
+```
+
+Each attribute is one import: the name is the local alias, the value is a
+path (an ordinary string, so `env.*` interpolation works). More than one
+`import{}` block may appear; duplicate aliases are an error, same as
+`locals`.
+
+Every import is a *whole-file* import — there's no way to import a single
+resource directly. The imported file is exposed under `imports.<alias>`,
+shaped the same way the file itself is:
+
+```
+imports.<alias>.produce.<kind>.<name>          # a produce "<kind>" "<name>" {} in that file
+imports.<alias>.consume.<kind>.<name>
+imports.<alias>.transform.<kind>.<name>
+imports.<alias>.pipeline.<name>.produce         # that file's pipeline "<name>" {}, as ordered ref lists
+imports.<alias>.pipeline.<name>.consume
+imports.<alias>.pipeline.<name>.transform
+imports.<alias>.pipeline.<name>.stop-after
+imports.<alias>.pipeline.<name>.exit-on-error
+```
+
+Use it like any other ref, in any attribute where refs are valid:
+
+```hcl
+import {
+  shared = "shared.psy"
+}
+
+pipeline "main" {
+  produce = [produce.sequence.s]
+  consume = [imports.shared.consume.file.out]     # one resource from shared.psy
+}
+
+pipeline "reuse" {
+  produce = imports.shared.pipeline.upstream.produce   # a whole producer list, reused verbatim
+  consume = [imports.shared.consume.file.out]
+}
+```
+
+Imports are **not transitive**: importing a file exposes only what *that
+file itself* declares, not whatever it in turn imports. Importing the same
+file from two different places resolves it once (its resources are shared,
+not duplicated), and an import cycle (A imports B imports A) is a parse
+error.
+
+## Running a file
+
+`psyduck run <file>.psy` builds and runs every `pipeline{}` block declared
+*directly* in that file — not ones only reachable through `imports.*`:
+
+- **Zero** pipelines in the file is an error; nothing runs.
+- **One** pipeline runs directly.
+- **More than one** run concurrently, each in its own goroutine, sharing the
+  process. `run` waits for all of them and exits non-zero if any of them
+  returned an error.
+
+`psyduck init`, `list`, and `show` take the same file argument. `init`
+resolves `plugin{}` declarations across the file's entire import closure —
+not just the file itself — since a plugin an imported resource depends on
+still needs to be fetched and built for the importing file to run.
 
 ## External plugins
 

--- a/docs/hcl.md
+++ b/docs/hcl.md
@@ -15,7 +15,7 @@ file, `import` it explicitly (see [Imports](#imports) below).
 A file is run by pointing the CLI at it directly:
 
 ```sh
-psyduck --chdir path/to/workspace run <file>.psy
+psyduck run path/to/<file>.psy
 ```
 
 Every `pipeline{}` block declared *directly* in that file runs: a file with

--- a/examples/dev.psy
+++ b/examples/dev.psy
@@ -1,4 +1,8 @@
 # count replaces the message with a running tally every n messages.
+import {
+  shared = "shared.psy"
+}
+
 produce "sequence" "dev" {
   stop-after = 3
 }
@@ -10,5 +14,5 @@ transform "count" "dev" {
 pipeline "dev" {
   produce   = [produce.sequence.dev]
   transform = [transform.count.dev]
-  consume   = [consume.file.out]
+  consume   = [imports.shared.consume.file.out]
 }

--- a/examples/encoding.psy
+++ b/examples/encoding.psy
@@ -1,4 +1,8 @@
 # recode is the universal codec converter: decode one format, encode another.
+import {
+  shared = "shared.psy"
+}
+
 produce "generate" "encoding" {
   values = ["hello", "world"]
 }
@@ -11,5 +15,5 @@ transform "recode" "b64" {
 pipeline "encoding" {
   produce   = [produce.generate.encoding]
   transform = [transform.recode.b64]
-  consume   = [consume.file.out]
+  consume   = [imports.shared.consume.file.out]
 }

--- a/examples/file-read.psy
+++ b/examples/file-read.psy
@@ -1,5 +1,9 @@
 # The file transport reads the way it writes. Here it reads lines from
 # env.PSYDUCK_IN, uppercases them, and writes them back out.
+import {
+  shared = "shared.psy"
+}
+
 produce "file" "file-read" {
   sep      = "\n"
   location = env.PSYDUCK_IN
@@ -10,5 +14,5 @@ transform "upper" "file-read" {}
 pipeline "file-read" {
   produce   = [produce.file.file-read]
   transform = [transform.upper.file-read]
-  consume   = [consume.file.out]
+  consume   = [imports.shared.consume.file.out]
 }

--- a/examples/flow.psy
+++ b/examples/flow.psy
@@ -1,4 +1,8 @@
 # sequence emits an integer stream; head passes only the first n.
+import {
+  shared = "shared.psy"
+}
+
 produce "sequence" "flow" {
   stop-after = 10
 }
@@ -10,5 +14,5 @@ transform "head" "flow" {
 pipeline "flow" {
   produce   = [produce.sequence.flow]
   transform = [transform.head.flow]
-  consume   = [consume.file.out]
+  consume   = [imports.shared.consume.file.out]
 }

--- a/examples/http-listen.psy
+++ b/examples/http-listen.psy
@@ -1,5 +1,9 @@
 # http-listen receives request bodies as messages. Build-only: the server only
 # binds when the pipeline runs.
+import {
+  shared = "shared.psy"
+}
+
 produce "http-listen" "hook" {
   address = ":0"
   path    = "/ingest"
@@ -10,5 +14,5 @@ produce "http-listen" "hook" {
 
 pipeline "http-listen" {
   produce = [produce.http-listen.hook]
-  consume = [consume.trash.sink]
+  consume = [imports.shared.consume.trash.sink]
 }

--- a/examples/http-request.psy
+++ b/examples/http-request.psy
@@ -1,6 +1,10 @@
 # The request transport is dual-role: producing polls the URL, consuming posts
 # each message. Build-only (no network): parsing + building validates the
 # spec — map headers, list success codes, required url.
+import {
+  shared = "shared.psy"
+}
+
 produce "request" "api" {
   url           = "http://example.invalid/items"
   headers       = { "Authorization" = "Bearer x" }
@@ -11,5 +15,5 @@ produce "request" "api" {
 
 pipeline "http-request" {
   produce = [produce.request.api]
-  consume = [consume.trash.sink]
+  consume = [imports.shared.consume.trash.sink]
 }

--- a/examples/jq.psy
+++ b/examples/jq.psy
@@ -1,4 +1,8 @@
 # filter drops messages whose predicate is false/null; jq reshapes what remains.
+import {
+  shared = "shared.psy"
+}
+
 produce "generate" "jq" {
   values = [
     "{\"v\":1,\"keep\":true}",
@@ -17,5 +21,5 @@ transform "jq" "v" {
 pipeline "jq" {
   produce   = [produce.generate.jq]
   transform = [transform.filter.jq, transform.jq.v]
-  consume   = [consume.file.out]
+  consume   = [imports.shared.consume.file.out]
 }

--- a/examples/keyed.psy
+++ b/examples/keyed.psy
@@ -1,5 +1,9 @@
 # dedupe drops repeat keys; path = [...] selects the key from object data. The
 # original message passes through unchanged.
+import {
+  shared = "shared.psy"
+}
+
 produce "generate" "keyed" {
   values = [
     "{\"id\":1}",
@@ -15,5 +19,5 @@ transform "dedupe" "keyed" {
 pipeline "keyed" {
   produce   = [produce.generate.keyed]
   transform = [transform.dedupe.keyed]
-  consume   = [consume.file.out]
+  consume   = [imports.shared.consume.file.out]
 }

--- a/examples/meta-socket.psy
+++ b/examples/meta-socket.psy
@@ -2,6 +2,10 @@
 # from a sequence and writes it to a unix socket; another listens on that
 # socket and uses the stream as its produce-from description. Parse-only here
 # (the runtime path is covered by stdlib/integration_test.go).
+import {
+  shared = "shared.psy"
+}
+
 produce "sequence" "pages" {
   stop-after = 3
 }
@@ -37,5 +41,5 @@ produce "listen" "meta-in" {
 
 pipeline "scrape" {
   produce-from = produce.listen.meta-in
-  consume      = [consume.trash.sink]
+  consume      = [imports.shared.consume.trash.sink]
 }

--- a/examples/render.psy
+++ b/examples/render.psy
@@ -1,5 +1,9 @@
 # render formats a message; engine = template gives Go text/template with the
 # decoded object as the dot.
+import {
+  shared = "shared.psy"
+}
+
 produce "generate" "render" {
   values = ["{\"name\": \"ann\"}"]
 }
@@ -12,5 +16,5 @@ transform "render" "r" {
 pipeline "render" {
   produce   = [produce.generate.render]
   transform = [transform.render.r]
-  consume   = [consume.file.out]
+  consume   = [imports.shared.consume.file.out]
 }

--- a/examples/reshape.psy
+++ b/examples/reshape.psy
@@ -1,5 +1,9 @@
 # pick-map reshapes an object by walking source paths into new keys; set adds
 # a static field. Together they cover the extract-and-annotate use case.
+import {
+  shared = "shared.psy"
+}
+
 produce "generate" "reshape" {
   values = [
     "{\"user\": {\"name\": \"ann\"}, \"drop_me\": 1}",
@@ -18,5 +22,5 @@ transform "set" "tag" {
 pipeline "reshape" {
   produce   = [produce.generate.reshape]
   transform = [transform.pick-map.reshape, transform.set.tag]
-  consume   = [consume.file.out]
+  consume   = [imports.shared.consume.file.out]
 }

--- a/examples/select.psy
+++ b/examples/select.psy
@@ -1,5 +1,9 @@
 # pick extracts one value. path = [...] walks discrete/object data by key;
 # encode = "bytes" emits the leaf unquoted.
+import {
+  shared = "shared.psy"
+}
+
 produce "generate" "select" {
   values = [
     "{\"user\": {\"name\": \"ann\"}}",
@@ -15,5 +19,5 @@ transform "pick" "name" {
 pipeline "select" {
   produce   = [produce.generate.select]
   transform = [transform.pick.name]
-  consume   = [consume.file.out]
+  consume   = [imports.shared.consume.file.out]
 }

--- a/examples/shared.psy
+++ b/examples/shared.psy
@@ -1,4 +1,6 @@
-# Consumers shared across the examples in this workspace.
+# Consumers reused across the other files in examples/. Each file that wants
+# them declares its own `import { shared = "shared.psy" }` and references
+# imports.shared.consume.<name> — there's no implicit workspace-wide sharing.
 #
 # consume.file.out writes newline-framed messages to env.PSYDUCK_OUT. Every
 # tierRun example targets it; the test suite sets PSYDUCK_OUT to a temp file

--- a/examples/slicing.psy
+++ b/examples/slicing.psy
@@ -1,4 +1,8 @@
 # chunk splits continuous data into fixed windows, emitted as a JSON array.
+import {
+  shared = "shared.psy"
+}
+
 produce "generate" "slicing" {
   values = ["abcdef"]
 }
@@ -10,5 +14,5 @@ transform "chunk" "c" {
 pipeline "slicing" {
   produce   = [produce.generate.slicing]
   transform = [transform.chunk.c]
-  consume   = [consume.file.out]
+  consume   = [imports.shared.consume.file.out]
 }

--- a/examples/text.psy
+++ b/examples/text.psy
@@ -1,5 +1,9 @@
 # Text transformers work in the string domain (decode defaults to utf-8) and
 # stack like any other stage.
+import {
+  shared = "shared.psy"
+}
+
 produce "generate" "text" {
   values = ["  Hi There  "]
 }
@@ -16,5 +20,5 @@ transform "upper" "text" {}
 pipeline "text" {
   produce   = [produce.generate.text]
   transform = [transform.trim.t, transform.replace.r, transform.upper.text]
-  consume   = [consume.file.out]
+  consume   = [imports.shared.consume.file.out]
 }

--- a/examples_test.go
+++ b/examples_test.go
@@ -118,7 +118,7 @@ func runExample(t *testing.T, name string, fix fixture) {
 	}
 	entry := filepath.Join("examples", file)
 
-	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.SourceFromFile, plugins)
+	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.FileLoader, plugins)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}

--- a/examples_test.go
+++ b/examples_test.go
@@ -23,9 +23,11 @@ const (
 )
 
 // fixture holds the test data for one example pipeline. The .psy sources
-// live under examples/*.psy — one workspace, one file per example plus
-// shared.psy for the consumers reused across them.
+// live under examples/*.psy — each file is its own entry point; cross-file
+// reuse (e.g. shared.psy's consumers) goes through explicit import{} blocks
+// rather than directory-wide sharing.
 type fixture struct {
+	file   string // path under examples/; defaults to "<pipeline name>.psy"
 	tier   tier
 	input  string // written to a temp file and injected as PSYDUCK_IN; empty = no input
 	expect string // expected output, trailing newlines stripped; empty = not checked
@@ -81,13 +83,11 @@ var examples = map[string]fixture{
 	},
 	"http-request": {tier: tierBuild},
 	"http-listen":  {tier: tierBuild},
-	"config-gen":   {tier: tierParse},
-	"scrape":       {tier: tierParse},
+	"config-gen":   {file: "meta-socket.psy", tier: tierParse},
+	"scrape":       {file: "meta-socket.psy", tier: tierParse},
 }
 
 // TestExamples runs each pipeline registered in the examples map as a subtest.
-// Every subtest parses the whole examples/ workspace (so shared.psy and the
-// per-example .psy files link up), then builds/runs only the target pipeline.
 func TestExamples(t *testing.T) {
 	for name, fix := range examples {
 		fix := fix
@@ -112,17 +112,19 @@ func runExample(t *testing.T, name string, fix fixture) {
 		t.Setenv("PSYDUCK_IN", inPath)
 	}
 
-	sources, err := parse.SourceFromDir("examples")
-	if err != nil {
-		t.Fatalf("read examples/: %v", err)
+	file := fix.file
+	if file == "" {
+		file = name + ".psy"
 	}
-	pipelines, err := hcl.NewParserHCL().Parse(sources, plugins)
+	entry := filepath.Join("examples", file)
+
+	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.OSLoader, plugins)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	pipe, ok := pipelines[name]
 	if !ok {
-		t.Fatalf("pipeline %q not defined in examples/", name)
+		t.Fatalf("pipeline %q not defined in %s", name, entry)
 	}
 
 	if fix.tier == tierParse {
@@ -164,8 +166,10 @@ pipeline "check" {
   consume   = [consume.trash.sink]
 }`
 	plugins := []sdk.Plugin{stdlib.Plugin()}
-	pipelines, err := hcl.NewParserHCL().Parse(
-		[]parse.Source{{Name: "assert.psy", Content: []byte(src)}}, plugins)
+	load := func(path string) (parse.Source, error) {
+		return parse.Source{Name: path, Content: []byte(src)}, nil
+	}
+	pipelines, err := hcl.NewParserHCL().Parse("assert.psy", load, plugins)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples_test.go
+++ b/examples_test.go
@@ -118,7 +118,7 @@ func runExample(t *testing.T, name string, fix fixture) {
 	}
 	entry := filepath.Join("examples", file)
 
-	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.OSLoader, plugins)
+	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.SourceFromFile, plugins)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func cmdinit(ctx *cli.Context) error { // init is a different thing in go
 		return err
 	}
 
-	specs, err := hcl.NewParserHCL().Plugins(entry, parse.SourceFromFile)
+	specs, err := hcl.NewParserHCL().Plugins(entry, parse.FileLoader)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func loadPipelines(ctx *cli.Context) (map[string]parse.Pipeline, []sdk.Plugin, e
 	}
 	loaded = append(loaded, stdlib.Plugin())
 
-	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.SourceFromFile, loaded)
+	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.FileLoader, loaded)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/psyduck-etl/sdk"
 	"github.com/urfave/cli/v2"
@@ -24,7 +25,27 @@ func entryPath(ctx *cli.Context) (string, error) {
 	if !ctx.Args().Present() {
 		return "", fmt.Errorf("pipeline file required")
 	}
+	if err := rejectStrayFlags(ctx.Args().Tail()); err != nil {
+		return "", err
+	}
 	return ctx.Args().First(), nil
+}
+
+// rejectStrayFlags errors on any argument that looks like a flag. Go's
+// flag parsing stops recognizing flags at the first non-flag argument —
+// since the file is always that first argument here, a flag typed after
+// it (e.g. `psyduck list hello/main.psy --stat`) never reaches the flag
+// parser at all; it just lands, unrecognized, among the positional
+// arguments (ctx.Args().Tail()). Without this check that would silently
+// do nothing instead of erroring — or, for `show`, silently be treated as
+// a pipeline name to filter by.
+func rejectStrayFlags(args []string) error {
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			return fmt.Errorf("unrecognized flag %q (flags must come before the file argument)", a)
+		}
+	}
+	return nil
 }
 
 // storeFor returns the content-addressed plugin store for entry: a

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 
 	"github.com/psyduck-etl/sdk"
@@ -16,13 +16,21 @@ import (
 	"github.com/gastrodon/psyduck/stdlib"
 )
 
-// entryPath resolves the pipeline file argument (relative to --chdir) that
-// run/init/list/show all take as their first positional argument.
+// entryPath validates and returns the pipeline file argument that
+// run/init/list/show all take as their first positional argument. There's
+// no separate --chdir anymore — the file's own path is the only root
+// anything needs (imports resolve relative to it, and so does its store).
 func entryPath(ctx *cli.Context) (string, error) {
 	if !ctx.Args().Present() {
 		return "", fmt.Errorf("pipeline file required")
 	}
-	return path.Join(ctx.String("chdir"), ctx.Args().First()), nil
+	return ctx.Args().First(), nil
+}
+
+// storeFor returns the content-addressed plugin store for entry: a
+// .psyduck/ directory next to the file, alongside its .lock.
+func storeFor(entry string) *plugins.Store {
+	return plugins.NewStore(filepath.Join(filepath.Dir(entry), ".psyduck"))
 }
 
 func cmdinit(ctx *cli.Context) error { // init is a different thing in go
@@ -36,26 +44,31 @@ func cmdinit(ctx *cli.Context) error { // init is a different thing in go
 		return err
 	}
 
-	initPath := path.Join(ctx.String("chdir"), ".psyduck")
-	if err := os.MkdirAll(initPath, os.ModeDir|os.ModePerm); err != nil {
+	locked, err := storeFor(entry).Build(specs)
+	if err != nil {
 		return err
 	}
 
-	return plugins.NewStore(initPath).Build(specs)
+	return plugins.WriteLock(entry, &plugins.Lock{Plugins: locked})
 }
 
 // loadPipelines resolves entry and its transitive imports against the
-// loaded plugins + stdlib, and returns every pipeline{} declared directly
-// in entry (imported pipelines are data for entry to reuse, not part of
-// what runs).
+// plugins its lock file declares (see plugins.ReadLock — every file that's
+// run must have been init'd first, this isn't optional) plus stdlib, and
+// returns every pipeline{} declared directly in entry (imported pipelines
+// are data for entry to reuse, not part of what runs).
 func loadPipelines(ctx *cli.Context) (map[string]parse.Pipeline, []sdk.Plugin, error) {
 	entry, err := entryPath(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	initPath := path.Join(ctx.String("chdir"), ".psyduck")
-	loaded, err := plugins.NewStore(initPath).Load()
+	lock, err := plugins.ReadLock(entry)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	loaded, err := storeFor(entry).Load(lock.Plugins)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -204,14 +217,6 @@ func main() {
 	app := cli.App{
 		Name:  "psyduck",
 		Usage: "run and manage etl pipelines",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:      "chdir",
-				Usage:     "directory to execute from",
-				Value:     ".",
-				TakesFile: true,
-			},
-		},
 		Commands: []*cli.Command{
 			{
 				Name:      "run",

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func cmdinit(ctx *cli.Context) error { // init is a different thing in go
 		return err
 	}
 
-	specs, err := hcl.NewParserHCL().Plugins(entry, parse.OSLoader)
+	specs, err := hcl.NewParserHCL().Plugins(entry, parse.SourceFromFile)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func loadPipelines(ctx *cli.Context) (map[string]parse.Pipeline, []sdk.Plugin, e
 	}
 	loaded = append(loaded, stdlib.Plugin())
 
-	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.OSLoader, loaded)
+	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.SourceFromFile, loaded)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -16,13 +16,22 @@ import (
 	"github.com/gastrodon/psyduck/stdlib"
 )
 
+// entryPath resolves the pipeline file argument (relative to --chdir) that
+// run/init/list/show all take as their first positional argument.
+func entryPath(ctx *cli.Context) (string, error) {
+	if !ctx.Args().Present() {
+		return "", fmt.Errorf("pipeline file required")
+	}
+	return path.Join(ctx.String("chdir"), ctx.Args().First()), nil
+}
+
 func cmdinit(ctx *cli.Context) error { // init is a different thing in go
-	sources, err := parse.SourceFromDir(ctx.String("chdir"))
+	entry, err := entryPath(ctx)
 	if err != nil {
 		return err
 	}
 
-	specs, err := hcl.NewParserHCL().Plugins(sources)
+	specs, err := hcl.NewParserHCL().Plugins(entry, parse.OSLoader)
 	if err != nil {
 		return err
 	}
@@ -35,10 +44,12 @@ func cmdinit(ctx *cli.Context) error { // init is a different thing in go
 	return plugins.NewStore(initPath).Build(specs)
 }
 
-// loadPipelines parses every .psy source in the workspace against the
-// loaded plugins + stdlib.
+// loadPipelines resolves entry and its transitive imports against the
+// loaded plugins + stdlib, and returns every pipeline{} declared directly
+// in entry (imported pipelines are data for entry to reuse, not part of
+// what runs).
 func loadPipelines(ctx *cli.Context) (map[string]parse.Pipeline, []sdk.Plugin, error) {
-	sources, err := parse.SourceFromDir(ctx.String("chdir"))
+	entry, err := entryPath(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -50,35 +61,52 @@ func loadPipelines(ctx *cli.Context) (map[string]parse.Pipeline, []sdk.Plugin, e
 	}
 	loaded = append(loaded, stdlib.Plugin())
 
-	pipelines, err := hcl.NewParserHCL().Parse(sources, loaded)
+	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.OSLoader, loaded)
 	if err != nil {
 		return nil, nil, err
 	}
 	return pipelines, loaded, nil
 }
 
+// run builds every pipeline{} declared directly in the target file and
+// runs them. Zero pipelines is an error. One runs directly. More than one
+// run concurrently, one goroutine each; run returns the first error seen
+// (if any) once all of them have finished.
 func run(ctx *cli.Context) error {
-	if !ctx.Args().Present() {
-		return fmt.Errorf("target required")
-	}
-
 	pipelines, loaded, err := loadPipelines(ctx)
 	if err != nil {
 		return err
 	}
 
-	target := ctx.Args().First()
-	pipe, ok := pipelines[target]
-	if !ok {
-		return fmt.Errorf("no pipeline %q", target)
+	if len(pipelines) == 0 {
+		return fmt.Errorf("%s: declares no pipeline", ctx.Args().First())
 	}
 
-	pipeline, err := core.BuildPipeline(pipe, loaded)
-	if err != nil {
-		return err
+	built := make([]*core.Pipeline, 0, len(pipelines))
+	for _, pipe := range pipelines {
+		b, err := core.BuildPipeline(pipe, loaded)
+		if err != nil {
+			return err
+		}
+		built = append(built, b)
 	}
 
-	return core.RunPipeline(pipeline)
+	if len(built) == 1 {
+		return core.RunPipeline(built[0])
+	}
+
+	errs := make(chan error, len(built))
+	for _, b := range built {
+		go func(b *core.Pipeline) { errs <- core.RunPipeline(b) }(b)
+	}
+
+	var failed error
+	for range built {
+		if err := <-errs; err != nil && failed == nil {
+			failed = err
+		}
+	}
+	return failed
 }
 
 func sortedKeys[V any](m map[string]V) []string {
@@ -137,7 +165,7 @@ func show(ctx *cli.Context) error {
 		return err
 	}
 
-	names := ctx.Args().Slice()
+	names := ctx.Args().Slice()[1:] // args[0] is the entry file
 	if len(names) == 0 {
 		names = sortedNames(pipelines)
 	}
@@ -187,15 +215,17 @@ func main() {
 		Commands: []*cli.Command{
 			{
 				Name:      "run",
-				Usage:     "run a pipeline job",
+				Usage:     "run every pipeline declared in a file",
 				Action:    run,
 				Args:      true,
-				ArgsUsage: "pipeline name",
+				ArgsUsage: "pipeline file",
 			},
 			{
-				Name:   "list",
-				Usage:  "list pipelines by name",
-				Action: list,
+				Name:      "list",
+				Usage:     "list pipelines declared in a file",
+				Action:    list,
+				Args:      true,
+				ArgsUsage: "pipeline file",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
 						Name:  "stat",
@@ -208,13 +238,15 @@ func main() {
 				Usage:     "show pipeline resources and config",
 				Action:    show,
 				Args:      true,
-				ArgsUsage: "[pipeline name ...]",
+				ArgsUsage: "pipeline file [pipeline name ...]",
 			},
 			{
-				Name:   "init",
-				Usage:  "init a pipeline workspace",
-				Action: cmdinit,
-				Flags:  []cli.Flag{},
+				Name:      "init",
+				Usage:     "init a pipeline workspace for a file",
+				Action:    cmdinit,
+				Args:      true,
+				ArgsUsage: "pipeline file",
+				Flags:     []cli.Flag{},
 			},
 		},
 	}

--- a/parse/hcl/context.go
+++ b/parse/hcl/context.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	nsLocal = "local"
-	nsEnv   = "env"
+	nsLocal   = "local"
+	nsEnv     = "env"
+	nsImports = "imports"
 )
 
 // envNames statically collects the env.* attribute names queried by any
@@ -92,8 +93,10 @@ func extendEnv(ctx *hcl.EvalContext, names map[string]bool) *hcl.EvalContext {
 }
 
 // makeLocalsCtx merges all locals {} blocks across sources (duplicate keys
-// error) and returns the eval context exposing local.* and env.*.
-func makeLocalsCtx(blocks []*hcl.Block, env cty.Value) (*hcl.EvalContext, error) {
+// error) and returns the eval context exposing local.*, env.*, and
+// imports.* (the resolved import{} closure for this file, built by the
+// caller — see buildImportsValue in import.go).
+func makeLocalsCtx(blocks []*hcl.Block, env cty.Value, imports cty.Value) (*hcl.EvalContext, error) {
 	envCtx := &hcl.EvalContext{Variables: map[string]cty.Value{nsEnv: env}}
 
 	values := make(map[string]cty.Value)
@@ -118,18 +121,23 @@ func makeLocalsCtx(blocks []*hcl.Block, env cty.Value) (*hcl.EvalContext, error)
 
 	return &hcl.EvalContext{
 		Variables: map[string]cty.Value{
-			nsLocal: objOrEmpty(values),
-			nsEnv:   env,
+			nsLocal:   objOrEmpty(values),
+			nsEnv:     env,
+			nsImports: imports,
 		},
 	}, nil
 }
 
 // refTree builds nested cty objects from dotted ref paths, so that the HCL
 // expression `produce.constant.input` (or short-form `constant.input`)
-// evaluates to the flat ref string "produce.constant.input".
-type refTree map[string]any // string leaf | refTree branch
+// evaluates to the flat ref string "produce.constant.input". A leaf may be
+// a plain string (auto-wrapped as cty.StringVal — the common case, a
+// resource ref) or an already-built cty.Value (used for imports.* leaves
+// that carry lists or scalars, e.g. imports.alias.pipeline.name.produce or
+// .stop-after).
+type refTree map[string]any // string | cty.Value | refTree
 
-func (t refTree) insert(path []string, leaf string) error {
+func (t refTree) insert(path []string, leaf any) error {
 	head := path[0]
 	if len(path) == 1 {
 		if _, exists := t[head]; exists {
@@ -153,13 +161,16 @@ func (t refTree) insert(path []string, leaf string) error {
 }
 
 // vars flattens the tree into a variables map at the current level.
-// String leaves become cty.StringVal; branches recurse and become objects.
+// String leaves become cty.StringVal, cty.Value leaves are used as-is,
+// and branches recurse and become objects.
 func (t refTree) vars() map[string]cty.Value {
 	out := make(map[string]cty.Value, len(t))
 	for key, child := range t {
 		switch c := child.(type) {
 		case string:
 			out[key] = cty.StringVal(c)
+		case cty.Value:
+			out[key] = c
 		case refTree:
 			out[key] = c.value()
 		}

--- a/parse/hcl/hcl.go
+++ b/parse/hcl/hcl.go
@@ -4,8 +4,6 @@
 package hcl
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/psyduck-etl/sdk"
@@ -16,6 +14,7 @@ import (
 const (
 	blockLocals    = "locals"
 	blockPlugin    = "plugin"
+	blockImport    = "import"
 	blockProduce   = "produce"
 	blockConsume   = "consume"
 	blockTransform = "transform"
@@ -28,10 +27,13 @@ var verbKinds = map[string]sdk.Kind{
 	blockTransform: sdk.TRANSFORMER,
 }
 
+var resourceVerbs = []string{blockProduce, blockConsume, blockTransform}
+
 var topSchema = &hcl.BodySchema{
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: blockLocals},
 		{Type: blockPlugin, LabelNames: []string{"name"}},
+		{Type: blockImport},
 		{Type: blockProduce, LabelNames: []string{"resource", "name"}},
 		{Type: blockConsume, LabelNames: []string{"resource", "name"}},
 		{Type: blockTransform, LabelNames: []string{"resource", "name"}},
@@ -57,151 +59,112 @@ var pipelineSchema = &hcl.BodySchema{
 	},
 }
 
-// ParserHCL implements parse.Parser. It is stateless; both phases take the
-// sources they operate on.
+// ParserHCL implements parse.Parser. It is stateless; Plugins/Parse take
+// the entry file and a Loader to resolve import{} declarations with.
 type ParserHCL struct{}
 
 func NewParserHCL() *ParserHCL { return &ParserHCL{} }
 
-// topBlocks is every top-level block across all sources, bucketed by type.
+// topBlocks is every top-level block in one file, bucketed by type.
 // Resource blocks (produce/consume/transform) keep their block type.
 type topBlocks struct {
 	locals    []*hcl.Block
 	plugins   []*hcl.Block
+	imports   []*hcl.Block
 	resources []*hcl.Block
 	pipelines []*hcl.Block
 }
 
-func gather(sources []parse.Source) (*topBlocks, error) {
+// gatherOne parses one file's top-level blocks. Unlike the old workspace
+// model, this never merges across files — cross-file sharing goes through
+// import{} instead.
+func gatherOne(src parse.Source) (*topBlocks, error) {
 	parser := hclparse.NewParser()
 	out := new(topBlocks)
 
-	for _, src := range sources {
-		file, diags := parser.ParseHCL(src.Content, src.Name)
-		if diags.HasErrors() {
-			return nil, diags
-		}
+	file, diags := parser.ParseHCL(src.Content, src.Name)
+	if diags.HasErrors() {
+		return nil, diags
+	}
 
-		content, diags := file.Body.Content(topSchema)
-		if diags.HasErrors() {
-			return nil, diags
-		}
+	content, diags := file.Body.Content(topSchema)
+	if diags.HasErrors() {
+		return nil, diags
+	}
 
-		for _, block := range content.Blocks {
-			switch block.Type {
-			case blockLocals:
-				out.locals = append(out.locals, block)
-			case blockPlugin:
-				out.plugins = append(out.plugins, block)
-			case blockProduce, blockConsume, blockTransform:
-				out.resources = append(out.resources, block)
-			case blockPipeline:
-				out.pipelines = append(out.pipelines, block)
-			}
+	for _, block := range content.Blocks {
+		switch block.Type {
+		case blockLocals:
+			out.locals = append(out.locals, block)
+		case blockPlugin:
+			out.plugins = append(out.plugins, block)
+		case blockImport:
+			out.imports = append(out.imports, block)
+		case blockProduce, blockConsume, blockTransform:
+			out.resources = append(out.resources, block)
+		case blockPipeline:
+			out.pipelines = append(out.pipelines, block)
 		}
 	}
 
 	return out, nil
 }
 
-// Plugins is the cheap pre-pass: extract plugin {} declarations without
-// needing any plugins loaded.
-func (h *ParserHCL) Plugins(sources []parse.Source) ([]parse.Plugin, error) {
-	blocks, err := gather(sources)
-	if err != nil {
-		return nil, err
+// parsePluginSpec decodes one plugin{} block into a parse.Plugin.
+func parsePluginSpec(block *hcl.Block) (parse.Plugin, error) {
+	content, diags := block.Body.Content(pluginSchema)
+	if diags.HasErrors() {
+		return parse.Plugin{}, diags
 	}
 
-	specs := make([]parse.Plugin, 0, len(blocks.plugins))
-	for _, block := range blocks.plugins {
-		content, diags := block.Body.Content(pluginSchema)
+	spec := parse.Plugin{Name: block.Labels[0]}
+	if attr, ok := content.Attributes["source"]; ok {
+		v, diags := attr.Expr.Value(nil)
 		if diags.HasErrors() {
-			return nil, diags
+			return parse.Plugin{}, diags
 		}
-
-		spec := parse.Plugin{Name: block.Labels[0]}
-		if attr, ok := content.Attributes["source"]; ok {
-			v, diags := attr.Expr.Value(nil)
-			if diags.HasErrors() {
-				return nil, diags
-			}
-			spec.Source = v.AsString()
-		}
-		if attr, ok := content.Attributes["tag"]; ok {
-			v, diags := attr.Expr.Value(nil)
-			if diags.HasErrors() {
-				return nil, diags
-			}
-			spec.Tag = v.AsString()
-		}
-
-		specs = append(specs, spec)
+		spec.Source = v.AsString()
 	}
-
-	return specs, nil
+	if attr, ok := content.Attributes["tag"]; ok {
+		v, diags := attr.Expr.Value(nil)
+		if diags.HasErrors() {
+			return parse.Plugin{}, diags
+		}
+		spec.Tag = v.AsString()
+	}
+	return spec, nil
 }
 
-// Parse is the full pass: resolve values, resources, and pipelines against
-// the loaded plugins and return format-agnostic pipeline descriptions.
-func (h *ParserHCL) Parse(sources []parse.Source, plugins []sdk.Plugin) (map[string]parse.Pipeline, error) {
-	blocks, err := gather(sources)
+// Plugins extracts every plugin{} declaration reachable from entry,
+// following import{} blocks transitively. It's the cheap pre-pass: no
+// plugins need to be loaded to run it.
+func (h *ParserHCL) Plugins(entry string, load parse.Loader) ([]parse.Plugin, error) {
+	var out []parse.Plugin
+	err := collectPlugins(parse.ResolveImportPath("", entry), load, map[string]bool{}, map[string]bool{}, &out)
 	if err != nil {
 		return nil, err
 	}
+	return out, nil
+}
 
+// Parse resolves entry — and everything it transitively imports — against
+// the given plugins, and returns every pipeline{} declared directly in
+// entry.
+func (h *ParserHCL) Parse(entry string, load parse.Loader, plugins []sdk.Plugin) (map[string]parse.Pipeline, error) {
+	index := indexResources(plugins)
+	result, err := resolveFile(parse.ResolveImportPath("", entry), load, index, map[string]bool{}, map[string]*fileResult{})
+	if err != nil {
+		return nil, err
+	}
+	return result.pipelines, nil
+}
+
+func bodiesOf(groups ...[]*hcl.Block) []hcl.Body {
 	bodies := make([]hcl.Body, 0)
-	for _, group := range [][]*hcl.Block{blocks.locals, blocks.resources, blocks.pipelines} {
+	for _, group := range groups {
 		for _, block := range group {
 			bodies = append(bodies, block.Body)
 		}
 	}
-	env := envVal(envNames(bodies, nil))
-
-	localsCtx, err := makeLocalsCtx(blocks.locals, env)
-	if err != nil {
-		return nil, err
-	}
-
-	index := indexResources(plugins)
-
-	bindings := map[string]map[string]parse.Resource{
-		blockProduce:   {},
-		blockConsume:   {},
-		blockTransform: {},
-	}
-	for _, block := range blocks.resources {
-		binding, err := makeBinding(block, index, localsCtx)
-		if err != nil {
-			return nil, err
-		}
-		if prev, dup := bindings[block.Type][binding.Ref]; dup {
-			return nil, fmt.Errorf("duplicate resource %s at %s (previously defined at %s)",
-				binding.Ref, binding.Block.Origin(), prev.Block.Origin())
-		}
-		bindings[block.Type][binding.Ref] = binding
-	}
-
-	refCtxs := make(map[string]*hcl.EvalContext, len(bindings))
-	for verb, set := range bindings {
-		ctx, err := makeRefCtx(verb, set, localsCtx)
-		if err != nil {
-			return nil, err
-		}
-		refCtxs[verb] = ctx
-	}
-
-	pipelines := make(map[string]parse.Pipeline, len(blocks.pipelines))
-	for _, block := range blocks.pipelines {
-		pipe, err := makePipeline(block, bindings, refCtxs, localsCtx, index)
-		if err != nil {
-			return nil, err
-		}
-		if prev, dup := pipelines[pipe.Name]; dup {
-			return nil, fmt.Errorf("duplicate pipeline %q at %s (previously defined at %s)",
-				pipe.Name, pipe.Origin, prev.Origin)
-		}
-		pipelines[pipe.Name] = pipe
-	}
-
-	return pipelines, nil
+	return bodies
 }

--- a/parse/hcl/hcl_test.go
+++ b/parse/hcl/hcl_test.go
@@ -1,6 +1,7 @@
 package hcl
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -9,8 +10,22 @@ import (
 	"github.com/gastrodon/psyduck/parse"
 )
 
-func srcs(content string) []parse.Source {
-	return []parse.Source{{Name: "test.psy", Content: []byte(content)}}
+// files simulates a small multi-file workspace for import tests: an
+// in-memory parse.Loader backed by a map of path -> content.
+type files map[string]string
+
+func (f files) load(path string) (parse.Source, error) {
+	content, ok := f[path]
+	if !ok {
+		return parse.Source{}, fmt.Errorf("no such file %q", path)
+	}
+	return parse.Source{Name: path, Content: []byte(content)}, nil
+}
+
+// src wraps a single file's content as a one-file workspace, returning the
+// entry path and loader Plugins/Parse expect.
+func src(content string) (string, parse.Loader) {
+	return "test.psy", files{"test.psy": content}.load
 }
 
 type constantOpts struct {
@@ -71,7 +86,7 @@ func drainAll(t *testing.T, b parse.ResourceFunc) []parse.Resource {
 }
 
 func TestPlugins(t *testing.T) {
-	specs, err := NewParserHCL().Plugins(srcs(`
+	entry, load := src(`
 	plugin "amqp" {
 		source = "https://github.com/psyduck-etl/amqp"
 		tag    = "v1.2.3"
@@ -79,7 +94,8 @@ func TestPlugins(t *testing.T) {
 	plugin "local" {
 		source = "./plugins/local"
 	}
-	`))
+	`)
+	specs, err := NewParserHCL().Plugins(entry, load)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,10 +111,40 @@ func TestPlugins(t *testing.T) {
 	}
 }
 
+func TestPluginsFollowsImports(t *testing.T) {
+	fs := files{
+		"main.psy": `
+		import {
+			lib = "lib.psy"
+		}
+		plugin "amqp" {
+			source = "https://github.com/psyduck-etl/amqp"
+		}
+		`,
+		"lib.psy": `
+		plugin "local" {
+			source = "./plugins/local"
+		}
+		`,
+	}
+	specs, err := NewParserHCL().Plugins("main.psy", fs.load)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	names := map[string]bool{}
+	for _, s := range specs {
+		names[s.Name] = true
+	}
+	if !names["amqp"] || !names["local"] {
+		t.Fatalf("want plugins from both main and its import, got: %#v", specs)
+	}
+}
+
 func TestParse(t *testing.T) {
 	t.Setenv("PSYDUCK_TEST_VALUE", "from-env")
 
-	result, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	locals {
 		foo = "from-value"
 	}
@@ -124,7 +170,8 @@ func TestParse(t *testing.T) {
 		stop-after    = 9
 		exit-on-error = true
 	}
-	`), []sdk.Plugin{testPlugin("test")})
+	`)
+	result, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,27 +225,29 @@ func TestParse(t *testing.T) {
 func TestParseAmbiguousResource(t *testing.T) {
 	plugins := []sdk.Plugin{testPlugin("alpha"), testPlugin("beta")}
 
-	_, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	produce "constant" "p" {}
 	consume "alpha.trash" "t" {}
 	pipeline "main" {
 		produce = [produce.constant.p]
 		consume = [trash.t]
 	}
-	`), plugins)
+	`)
+	_, err := NewParserHCL().Parse(entry, load, plugins)
 	if err == nil || !strings.Contains(err.Error(), "alpha.constant, beta.constant") {
 		t.Fatalf("want ambiguity error listing candidates, got: %v", err)
 	}
 
 	// qualification resolves the ambiguity
-	_, err = NewParserHCL().Parse(srcs(`
+	entry, load = src(`
 	produce "beta.constant" "p" {}
 	consume "alpha.trash" "t" {}
 	pipeline "main" {
 		produce = [beta.constant.p]
 		consume = [alpha.trash.t]
 	}
-	`), plugins)
+	`)
+	_, err = NewParserHCL().Parse(entry, load, plugins)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +256,7 @@ func TestParseAmbiguousResource(t *testing.T) {
 func TestParseDuplicates(t *testing.T) {
 	plugins := []sdk.Plugin{testPlugin("test")}
 
-	_, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	produce "constant" "p" {}
 	produce "constant" "p" {}
 	consume "trash" "t" {}
@@ -215,12 +264,13 @@ func TestParseDuplicates(t *testing.T) {
 		produce = [produce.constant.p]
 		consume = [trash.t]
 	}
-	`), plugins)
+	`)
+	_, err := NewParserHCL().Parse(entry, load, plugins)
 	if err == nil || !strings.Contains(err.Error(), "duplicate resource") {
 		t.Fatalf("want duplicate resource error, got: %v", err)
 	}
 
-	_, err = NewParserHCL().Parse(srcs(`
+	entry, load = src(`
 	produce "constant" "p" {}
 	consume "trash" "t" {}
 	pipeline "main" {
@@ -231,7 +281,8 @@ func TestParseDuplicates(t *testing.T) {
 		produce = [produce.constant.p]
 		consume = [trash.t]
 	}
-	`), plugins)
+	`)
+	_, err = NewParserHCL().Parse(entry, load, plugins)
 	if err == nil || !strings.Contains(err.Error(), "duplicate pipeline") {
 		t.Fatalf("want duplicate pipeline error, got: %v", err)
 	}
@@ -240,7 +291,7 @@ func TestParseDuplicates(t *testing.T) {
 func TestParseProducerExclusivity(t *testing.T) {
 	plugins := []sdk.Plugin{testPlugin("test")}
 
-	_, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	produce "constant" "p" {}
 	consume "trash" "t" {}
 	pipeline "main" {
@@ -248,64 +299,228 @@ func TestParseProducerExclusivity(t *testing.T) {
 		produce-from = produce.constant.p
 		consume      = [trash.t]
 	}
-	`), plugins)
+	`)
+	_, err := NewParserHCL().Parse(entry, load, plugins)
 	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Fatalf("want exclusivity error, got: %v", err)
 	}
 
-	_, err = NewParserHCL().Parse(srcs(`
+	entry, load = src(`
 	consume "trash" "t" {}
 	pipeline "main" {
 		consume = [trash.t]
 	}
-	`), plugins)
+	`)
+	_, err = NewParserHCL().Parse(entry, load, plugins)
 	if err == nil || !strings.Contains(err.Error(), "produce or produce-from is required") {
 		t.Fatalf("want missing producer error, got: %v", err)
 	}
 }
 
-func TestParseMultiSource(t *testing.T) {
-	sources := []parse.Source{
-		{Name: "a.psy", Content: []byte(`
-		produce "constant" "p" { value = "hello" }
-		`)},
-		{Name: "b.psy", Content: []byte(`
+func TestParseImportWholeFile(t *testing.T) {
+	fs := files{
+		"a.psy": `produce "constant" "p" { value = "hello" }`,
+		"b.psy": `
+		import {
+			a = "a.psy"
+		}
 		consume "trash" "t" {}
 		pipeline "main" {
+			produce = [imports.a.produce.constant.p]
+			consume = [trash.t]
+		}
+		`,
+	}
+	pipelines, err := NewParserHCL().Parse("b.psy", fs.load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := drainAll(t, pipelines["main"].Producers)
+	if len(got) != 1 {
+		t.Fatalf("want 1 producer via import, got %d", len(got))
+	}
+	opts := new(constantOpts)
+	if err := got[0].Block.Decode(opts); err != nil {
+		t.Fatal(err)
+	}
+	if opts.Value != "hello" {
+		t.Fatalf("bad imported value: %q", opts.Value)
+	}
+
+	// b.psy's own pipeline set is exactly its own pipeline{} blocks —
+	// a.psy declares none, and importing it doesn't run it.
+	if len(pipelines) != 1 {
+		t.Fatalf("want exactly b.psy's own pipelines, got %#v", pipelines)
+	}
+}
+
+func TestParseImportReusesWholePipeline(t *testing.T) {
+	fs := files{
+		"a.psy": `
+		produce "constant" "p" { value = "hello" }
+		consume "trash" "t" {}
+		pipeline "inner" {
 			produce = [produce.constant.p]
 			consume = [trash.t]
 		}
-		`)},
+		`,
+		"b.psy": `
+		import {
+			a = "a.psy"
+		}
+		pipeline "outer" {
+			produce = imports.a.pipeline.inner.produce
+			consume = imports.a.pipeline.inner.consume
+		}
+		`,
 	}
-	pipelines, err := NewParserHCL().Parse(sources, []sdk.Plugin{testPlugin("test")})
+	pipelines, err := NewParserHCL().Parse("b.psy", fs.load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pipe, ok := pipelines["outer"]
+	if !ok {
+		t.Fatalf("want pipeline %q, got %#v", "outer", pipelines)
+	}
+	if got := drainAll(t, pipe.Producers); len(got) != 1 {
+		t.Fatalf("want 1 producer reused from imported pipeline, got %d", len(got))
+	}
+	if got := drainAll(t, pipe.Consumers); len(got) != 1 {
+		t.Fatalf("want 1 consumer reused from imported pipeline, got %d", len(got))
+	}
+}
+
+func TestParseImportPluginQualified(t *testing.T) {
+	plugins := []sdk.Plugin{testPlugin("alpha"), testPlugin("beta")}
+	fs := files{
+		"a.psy": `produce "beta.constant" "p" {}`,
+		"b.psy": `
+		import {
+			a = "a.psy"
+		}
+		consume "alpha.trash" "t" {}
+		pipeline "main" {
+			produce = [imports.a.produce.beta.constant.p]
+			consume = [alpha.trash.t]
+		}
+		`,
+	}
+	pipelines, err := NewParserHCL().Parse("b.psy", fs.load, plugins)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got := drainAll(t, pipelines["main"].Producers); len(got) != 1 {
-		t.Fatalf("want 1 producer across sources, got %d", len(got))
+		t.Fatalf("want 1 producer via qualified import, got %d", len(got))
 	}
 }
 
-func TestParseDuplicateValueKeyAcrossSources(t *testing.T) {
-	sources := []parse.Source{
-		{Name: "a.psy", Content: []byte(`locals { foo = "first" }`)},
-		{Name: "b.psy", Content: []byte(`locals { foo = "second" }`)},
+func TestParseImportCycle(t *testing.T) {
+	fs := files{
+		"a.psy": `import { b = "b.psy" }`,
+		"b.psy": `import { a = "a.psy" }`,
 	}
-	_, err := NewParserHCL().Parse(sources, nil)
+	_, err := NewParserHCL().Parse("a.psy", fs.load, []sdk.Plugin{testPlugin("test")})
+	if err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("want import cycle error, got: %v", err)
+	}
+}
+
+func TestParseImportDiamond(t *testing.T) {
+	fs := files{
+		"d.psy": `produce "constant" "p" { value = "shared" }`,
+		"b.psy": `
+		import { d = "d.psy" }
+		consume "trash" "t" {}
+		pipeline "via-b" {
+			produce = [imports.d.produce.constant.p]
+			consume = [trash.t]
+		}
+		`,
+		"c.psy": `
+		import { d = "d.psy" }
+		consume "trash" "t" {}
+		pipeline "via-c" {
+			produce = [imports.d.produce.constant.p]
+			consume = [trash.t]
+		}
+		`,
+		"a.psy": `
+		import {
+			b = "b.psy"
+			c = "c.psy"
+		}
+		consume "trash" "t" {}
+		pipeline "main" {
+			produce = [imports.b.pipeline.via-b.produce[0], imports.c.pipeline.via-c.produce[0]]
+			consume = [trash.t]
+		}
+		`,
+	}
+	// b.psy and c.psy both import d.psy; d.psy should resolve once (not
+	// error as a spurious duplicate or cycle), and be reachable through
+	// both paths.
+	pipelines, err := NewParserHCL().Parse("a.psy", fs.load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatalf("diamond import should resolve cleanly, got: %v", err)
+	}
+	if got := drainAll(t, pipelines["main"].Producers); len(got) != 2 {
+		t.Fatalf("want 2 producers reached via the diamond, got %d", len(got))
+	}
+}
+
+func TestParseDuplicateLocal(t *testing.T) {
+	entry, load := src(`
+	locals { foo = "first" }
+	locals { foo = "second" }
+	`)
+	_, err := NewParserHCL().Parse(entry, load, nil)
 	if err == nil || !strings.Contains(err.Error(), `duplicate local "foo"`) {
 		t.Fatalf("want duplicate local error, got: %v", err)
 	}
 }
 
+func TestParseLocalsNotSharedAcrossImports(t *testing.T) {
+	// Each file has its own locals{} namespace; two different files
+	// declaring the same local key is not a conflict.
+	fs := files{
+		"a.psy": `locals { foo = "from-a" }`,
+		"b.psy": `
+		import { a = "a.psy" }
+		locals { foo = "from-b" }
+		produce "constant" "p" { value = local.foo }
+		consume "trash" "t" {}
+		pipeline "main" {
+			produce = [produce.constant.p]
+			consume = [trash.t]
+		}
+		`,
+	}
+	pipelines, err := NewParserHCL().Parse("b.psy", fs.load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := drainAll(t, pipelines["main"].Producers)
+	opts := new(constantOpts)
+	if err := got[0].Block.Decode(opts); err != nil {
+		t.Fatal(err)
+	}
+	if opts.Value != "from-b" {
+		t.Fatalf("local.* leaked across import boundary: %q", opts.Value)
+	}
+}
+
 func TestParseUnknownQualifiedPlugin(t *testing.T) {
-	_, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	produce "unknown.constant" "p" {}
 	consume "trash" "t" {}
 	pipeline "main" {
 		produce = [unknown.constant.p]
 		consume = [trash.t]
 	}
-	`), []sdk.Plugin{testPlugin("test")})
+	`)
+	_, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), `unknown plugin "unknown"`) {
 		t.Fatalf("want unknown plugin error, got: %v", err)
 	}
@@ -314,13 +529,14 @@ func TestParseUnknownQualifiedPlugin(t *testing.T) {
 func TestParseUnknownResourceRef(t *testing.T) {
 	// References to undeclared resources fail at HCL eval time ("Unknown variable"),
 	// before resolveRefs is reached — the ref context and bindings map are always in sync.
-	_, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	consume "trash" "t" {}
 	pipeline "main" {
 		produce = [produce.constant.nonexistent]
 		consume = [trash.t]
 	}
-	`), []sdk.Plugin{testPlugin("test")})
+	`)
+	_, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), "Unknown variable") {
 		t.Fatalf("want unknown variable error, got: %v", err)
 	}
@@ -343,14 +559,15 @@ func TestParseReservedNamespaceCollision(t *testing.T) {
 			},
 		},
 	)
-	_, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	produce "local.constant" "p" {}
 	consume "trash" "t" {}
 	pipeline "main" {
 		produce = [local.constant.p]
 		consume = [trash.t]
 	}
-	`), []sdk.Plugin{valuePlugin, testPlugin("test")})
+	`)
+	_, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{valuePlugin, testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), "collides with reserved namespace") {
 		t.Fatalf("want namespace collision error, got: %v", err)
 	}
@@ -358,14 +575,15 @@ func TestParseReservedNamespaceCollision(t *testing.T) {
 
 func TestParseUnsetEnv(t *testing.T) {
 	// env vars are prescanned; unset-but-queried ones resolve to ""
-	result, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	produce "constant" "p" { value = env.PSYDUCK_DEFINITELY_UNSET_XYZ }
 	consume "trash" "t" {}
 	pipeline "main" {
 		produce = [produce.constant.p]
 		consume = [trash.t]
 	}
-	`), []sdk.Plugin{testPlugin("test")})
+	`)
+	result, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -380,14 +598,15 @@ func TestParseUnsetEnv(t *testing.T) {
 	}
 
 	// non-env unknown roots still error
-	_, err = NewParserHCL().Parse(srcs(`
+	entry, load = src(`
 	produce "constant" "p" { value = bogus.thing }
 	consume "trash" "t" {}
 	pipeline "main" {
 		produce = [produce.constant.p]
 		consume = [trash.t]
 	}
-	`), []sdk.Plugin{testPlugin("test")})
+	`)
+	_, err = NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), "Unknown variable") {
 		t.Fatalf("want unknown variable error, got: %v", err)
 	}
@@ -395,14 +614,15 @@ func TestParseUnsetEnv(t *testing.T) {
 
 func TestParseUnknownAttribute(t *testing.T) {
 	// typo'd option names error at parse time (strict schema)
-	_, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	produce "constant" "p" { valeu = "x" }
 	consume "trash" "t" {}
 	pipeline "main" {
 		produce = [produce.constant.p]
 		consume = [trash.t]
 	}
-	`), []sdk.Plugin{testPlugin("test")})
+	`)
+	_, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), "Unsupported argument") {
 		t.Fatalf("want unsupported argument error, got: %v", err)
 	}
@@ -410,14 +630,15 @@ func TestParseUnknownAttribute(t *testing.T) {
 
 func TestParseEagerConfigError(t *testing.T) {
 	// bad option values error at parse time, not at bind time
-	_, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	produce "constant" "p" { value = ["not", "a", "string"] }
 	consume "trash" "t" {}
 	pipeline "main" {
 		produce = [produce.constant.p]
 		consume = [trash.t]
 	}
-	`), []sdk.Plugin{testPlugin("test")})
+	`)
+	_, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), "invalid value for value") {
 		t.Fatalf("want eager conversion error, got: %v", err)
 	}
@@ -439,14 +660,15 @@ func TestParseProduceFromEnv(t *testing.T) {
 		},
 	)
 
-	result, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	produce "seed" "s" {}
 	consume "trash" "t" {}
 	pipeline "main" {
 		produce-from = produce.seed.s
 		consume      = [trash.t]
 	}
-	`), []sdk.Plugin{testPlugin("test"), seed})
+	`)
+	result, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test"), seed})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -480,14 +702,15 @@ func TestParseProduceFrom(t *testing.T) {
 		},
 	)
 
-	result, err := NewParserHCL().Parse(srcs(`
+	entry, load := src(`
 	produce "seed" "s" {}
 	consume "trash" "t" {}
 	pipeline "main" {
 		produce-from = produce.seed.s
 		consume      = [trash.t]
 	}
-	`), []sdk.Plugin{testPlugin("test"), meta})
+	`)
+	result, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test"), meta})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/parse/hcl/import.go
+++ b/parse/hcl/import.go
@@ -1,0 +1,350 @@
+package hcl
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/gastrodon/psyduck/parse"
+)
+
+// resolveImportAttrs merges the attributes of every import{} block in a
+// file (duplicate alias errors, mirroring makeLocalsCtx) and evaluates
+// each path expression against ctx, returning alias -> path string.
+// Import path expressions only see env.* — not local.* or imports.* from
+// other imports — so import resolution never has to wait on the rest of
+// the file's own eval context.
+func resolveImportAttrs(blocks []*hcl.Block, ctx *hcl.EvalContext) (map[string]string, error) {
+	out := make(map[string]string)
+	for _, block := range blocks {
+		attrs, diags := block.Body.JustAttributes()
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		for name, attr := range attrs {
+			if _, dup := out[name]; dup {
+				return nil, fmt.Errorf("duplicate import %q at %s", name, attr.Range)
+			}
+			v, diags := attr.Expr.Value(ctx)
+			if diags.HasErrors() {
+				return nil, diags
+			}
+			str, err := ctyConvertString(v)
+			if err != nil {
+				return nil, fmt.Errorf("import %q at %s: %w", name, attr.Range, err)
+			}
+			out[name] = str.AsString()
+		}
+	}
+	return out, nil
+}
+
+func ctyConvertString(v cty.Value) (cty.Value, error) {
+	if v.IsNull() {
+		return cty.NilVal, fmt.Errorf("import path must not be null")
+	}
+	if v.Type() == cty.String {
+		return v, nil
+	}
+	return cty.Value{}, fmt.Errorf("import path must be a string, got %s", v.Type().FriendlyName())
+}
+
+// importEnvCtx builds the minimal env.*-only eval context used to resolve
+// import{} path expressions in a file.
+func importEnvCtx(imports []*hcl.Block) *hcl.EvalContext {
+	env := envVal(envNames(bodiesOf(imports), nil))
+	return &hcl.EvalContext{Variables: map[string]cty.Value{nsEnv: env}}
+}
+
+// fileResult is what resolving one file (its own blocks, with its own
+// imports already folded in) produces: its own resource bindings —
+// exposed to importers under imports.<alias> — and its own pipeline{}
+// blocks. Imports are not transitive: importing a file exposes only that
+// file's own declarations, not whatever it in turn imported.
+type fileResult struct {
+	bindings  map[string]map[string]parse.Resource // verb -> ref -> Resource, this file's own
+	pipelines map[string]parse.Pipeline            // this file's own pipeline{} blocks
+}
+
+// collectPlugins walks entry and its transitive imports, collecting every
+// plugin{} declaration. It shares path resolution and cycle detection
+// with resolveFile but doesn't need to resolve resources or pipelines.
+func collectPlugins(path string, load parse.Loader, visiting, seen map[string]bool, out *[]parse.Plugin) error {
+	if seen[path] {
+		return nil
+	}
+	if visiting[path] {
+		return fmt.Errorf("import cycle detected at %s", path)
+	}
+	visiting[path] = true
+	defer delete(visiting, path)
+
+	src, err := load(path)
+	if err != nil {
+		return err
+	}
+	blocks, err := gatherOne(src)
+	if err != nil {
+		return err
+	}
+
+	for _, block := range blocks.plugins {
+		spec, err := parsePluginSpec(block)
+		if err != nil {
+			return err
+		}
+		*out = append(*out, spec)
+	}
+
+	aliases, err := resolveImportAttrs(blocks.imports, importEnvCtx(blocks.imports))
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	for alias, importPath := range aliases {
+		childPath := parse.ResolveImportPath(path, importPath)
+		if err := collectPlugins(childPath, load, visiting, seen, out); err != nil {
+			return fmt.Errorf("import %q at %s: %w", alias, path, err)
+		}
+	}
+
+	seen[path] = true
+	return nil
+}
+
+// resolveFile fully resolves one file: its own env/locals, its imports
+// (recursively, each producing a fileResult folded into this file's
+// imports.* namespace), its own resources, and its own pipelines.
+func resolveFile(
+	path string,
+	load parse.Loader,
+	index *resourceIndex,
+	visiting map[string]bool,
+	cache map[string]*fileResult,
+) (*fileResult, error) {
+	if cached, ok := cache[path]; ok {
+		return cached, nil
+	}
+	if visiting[path] {
+		return nil, fmt.Errorf("import cycle detected at %s", path)
+	}
+	visiting[path] = true
+	defer delete(visiting, path)
+
+	src, err := load(path)
+	if err != nil {
+		return nil, err
+	}
+	blocks, err := gatherOne(src)
+	if err != nil {
+		return nil, err
+	}
+
+	// Imports first: path expressions only see env.*, so this never
+	// depends on the rest of this file's own resolution.
+	importAliases, err := resolveImportAttrs(blocks.imports, importEnvCtx(blocks.imports))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+
+	importResults := make(map[string]*fileResult, len(importAliases))
+	for alias, importPath := range importAliases {
+		childPath := parse.ResolveImportPath(path, importPath)
+		child, err := resolveFile(childPath, load, index, visiting, cache)
+		if err != nil {
+			return nil, fmt.Errorf("import %q at %s: %w", alias, path, err)
+		}
+		importResults[alias] = child
+	}
+
+	importsVal, err := buildImportsValue(importResults)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+
+	env := envVal(envNames(bodiesOf(blocks.locals, blocks.resources, blocks.pipelines), nil))
+	localsCtx, err := makeLocalsCtx(blocks.locals, env, importsVal)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+
+	// This file's own resources, keyed by their plain (unqualified) ref —
+	// what gets exposed to importers, and what local pipeline{} blocks in
+	// this file see via the short/verb-qualified form.
+	own := map[string]map[string]parse.Resource{
+		blockProduce:   {},
+		blockConsume:   {},
+		blockTransform: {},
+	}
+	for _, block := range blocks.resources {
+		binding, err := makeBinding(block, index, localsCtx)
+		if err != nil {
+			return nil, err
+		}
+		if prev, dup := own[block.Type][binding.Ref]; dup {
+			return nil, fmt.Errorf("duplicate resource %s at %s (previously defined at %s)",
+				binding.Ref, binding.Block.Origin(), prev.Block.Origin())
+		}
+		own[block.Type][binding.Ref] = binding
+	}
+
+	// refCtxs are built from local bindings only — imports.* is already
+	// visible via localsCtx (merged into every verb's context below).
+	refCtxs := make(map[string]*hcl.EvalContext, len(resourceVerbs))
+	for _, verb := range resourceVerbs {
+		ctx, err := makeRefCtx(verb, own[verb], localsCtx)
+		if err != nil {
+			return nil, err
+		}
+		refCtxs[verb] = ctx
+	}
+
+	// lookupBindings is what resolveRefs actually searches: this file's
+	// own resources plus every imported resource under its qualified
+	// imports.<alias>.<ref> key, matching exactly the string an
+	// imports.<alias>... expression evaluates to. Resources reachable only
+	// through an imported pipeline's produce/consume/transform list (which
+	// may in turn have come from *that* file's own imports — no
+	// transitive re-export of plain bindings) get a synthetic
+	// imports.<alias>.pipeline.<name>.<verb>[i] key instead, matching
+	// pipelineSlotKey/refListVal below.
+	lookupBindings := map[string]map[string]parse.Resource{
+		blockProduce:   cloneResourceMap(own[blockProduce]),
+		blockConsume:   cloneResourceMap(own[blockConsume]),
+		blockTransform: cloneResourceMap(own[blockTransform]),
+	}
+	for alias, child := range importResults {
+		for verb, set := range child.bindings {
+			for ref, res := range set {
+				lookupBindings[verb]["imports."+alias+"."+ref] = res
+			}
+		}
+		for pname, pipe := range child.pipelines {
+			for _, slot := range pipelineSlots(pipe) {
+				for i, res := range slot.resources {
+					lookupBindings[slot.verb][pipelineSlotKey(alias, pname, slot.verb, i)] = res
+				}
+			}
+		}
+	}
+
+	pipelines := make(map[string]parse.Pipeline, len(blocks.pipelines))
+	for _, block := range blocks.pipelines {
+		pipe, err := makePipeline(block, lookupBindings, refCtxs, localsCtx, index)
+		if err != nil {
+			return nil, err
+		}
+		if prev, dup := pipelines[pipe.Name]; dup {
+			return nil, fmt.Errorf("duplicate pipeline %q at %s (previously defined at %s)",
+				pipe.Name, pipe.Origin, prev.Origin)
+		}
+		pipelines[pipe.Name] = pipe
+	}
+
+	result := &fileResult{bindings: own, pipelines: pipelines}
+	cache[path] = result
+	return result, nil
+}
+
+func cloneResourceMap(m map[string]parse.Resource) map[string]parse.Resource {
+	out := make(map[string]parse.Resource, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// buildImportsValue builds the imports.* object exposed to a file's own
+// eval context: one key per alias, shaped as
+// imports.<alias>.{produce,consume,transform}.<kind>.<name> for resources
+// (or ...<plugin>.<kind>.<name> when the resource's own ref was
+// plugin-qualified — imports mirror whatever qualification the imported
+// file itself used, same as its own local refs) and
+// imports.<alias>.pipeline.<name>.{produce,consume,transform,
+// stop-after,exit-on-error} for that file's pipeline{} blocks.
+func buildImportsValue(results map[string]*fileResult) (cty.Value, error) {
+	imports := refTree{}
+	for alias, r := range results {
+		aliasTree := refTree{
+			blockProduce:   refTree{},
+			blockConsume:   refTree{},
+			blockTransform: refTree{},
+		}
+		for _, verb := range resourceVerbs {
+			verbTree := aliasTree[verb].(refTree)
+			for ref := range r.bindings[verb] {
+				// ref is "<verb>.<kind>.<name>" or, when the resource was
+				// declared plugin-qualified, "<verb>.<plugin>.<kind>.<name>".
+				// Either way, dropping just the verb segment gives the
+				// right nested path.
+				rest := strings.SplitN(ref, ".", 2)
+				if len(rest) != 2 {
+					return cty.NilVal, fmt.Errorf("malformed resource ref %q", ref)
+				}
+				if err := verbTree.insert(strings.Split(rest[1], "."), "imports."+alias+"."+ref); err != nil {
+					return cty.NilVal, fmt.Errorf("imports.%s: %w", alias, err)
+				}
+			}
+		}
+
+		pipelineTree := refTree{}
+		for pname, pipe := range r.pipelines {
+			slot := refTree{
+				"stop-after":    cty.NumberIntVal(int64(pipe.StopAfter)),
+				"exit-on-error": cty.BoolVal(pipe.ExitOnError),
+			}
+			for _, s := range pipelineSlots(pipe) {
+				slot[s.verb] = refListVal(alias, pname, s.verb, s.resources)
+			}
+			pipelineTree[pname] = slot
+		}
+		aliasTree["pipeline"] = pipelineTree
+
+		imports[alias] = aliasTree
+	}
+	return imports.value(), nil
+}
+
+// pipelineResourceSlot pairs one produce/consume/transform slot of a
+// pipeline{} with its resolved resources, for iterating all three
+// uniformly.
+type pipelineResourceSlot struct {
+	verb      string
+	resources []parse.Resource
+}
+
+func pipelineSlots(pipe parse.Pipeline) []pipelineResourceSlot {
+	return []pipelineResourceSlot{
+		{blockProduce, pipe.Spec.Producers},
+		{blockConsume, pipe.Spec.Consumers},
+		{blockTransform, pipe.Spec.Transformers},
+	}
+}
+
+// pipelineSlotKey is the synthetic lookup key for the i'th resource in one
+// imported pipeline's produce/consume/transform slot. It's synthetic
+// (rather than reusing the resource's own Ref) because that resource may
+// itself have come from a further import inside the imported file — Refs
+// don't carry that provenance, and plain bindings aren't transitively
+// re-exported, so a fresh, always-reachable key is needed here. Used both
+// as the list element strings imports.<alias>.pipeline.<name>.<verb>
+// evaluates to (buildImportsValue) and as the matching lookupBindings key
+// (resolveFile), so the two always agree.
+func pipelineSlotKey(alias, pname, verb string, index int) string {
+	return fmt.Sprintf("imports.%s.pipeline.%s.%s[%d]", alias, pname, verb, index)
+}
+
+// refListVal builds the ordered list of qualified refs for one
+// pipeline{}'s producer/consumer/transformer slot, as exposed through
+// imports.<alias>.pipeline.<name>.<verb>.
+func refListVal(alias, pname, verb string, resources []parse.Resource) cty.Value {
+	if len(resources) == 0 {
+		return cty.ListValEmpty(cty.String)
+	}
+	vals := make([]cty.Value, len(resources))
+	for i := range resources {
+		vals[i] = cty.StringVal(pipelineSlotKey(alias, pname, verb, i))
+	}
+	return cty.ListVal(vals)
+}

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -16,13 +16,15 @@ type Plugin struct {
 // imports) are followed on demand via load. Parsing is two-phase because
 // plugin declarations live in the same sources being parsed:
 //
-//	// init: extract specs (following imports), build the store
-//	specs := parser.Plugins(entry, parse.OSLoader)
-//	store.Build(specs)
+//	// init: extract specs (following imports), build the store, lock it
+//	specs := parser.Plugins(entry, parse.SourceFromFile)
+//	locked, err := store.Build(specs)
+//	plugins.WriteLock(entry, &plugins.Lock{Plugins: locked})
 //
-//	// run: load from the store, then fully parse
-//	plugins := store.Load()
-//	pipelines, err := parser.Parse(entry, parse.OSLoader, plugins)
+//	// run: read the lock, load from the store, then fully parse
+//	lock, err := plugins.ReadLock(entry)
+//	loaded, err := store.Load(lock.Plugins)
+//	pipelines, err := parser.Parse(entry, parse.SourceFromFile, loaded)
 type Parser interface {
 	// Plugins extracts every plugin{} declaration reachable from entry,
 	// following import{} blocks transitively. It must not require loaded

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -11,23 +11,30 @@ type Plugin struct {
 }
 
 // Parser bridges a configuration language (HCL, YAML, ...) to the pipeline
-// descriptions core runs. Parsing is two-phase because plugin declarations
-// live in the same sources being parsed:
+// descriptions core runs. Parsing operates on one entry file at a time;
+// import{} declarations inside it (and transitively inside whatever it
+// imports) are followed on demand via load. Parsing is two-phase because
+// plugin declarations live in the same sources being parsed:
 //
-//	// init: extract specs, build the store
-//	specs := parser.Plugins(sources)
+//	// init: extract specs (following imports), build the store
+//	specs := parser.Plugins(entry, parse.OSLoader)
 //	store.Build(specs)
 //
 //	// run: load from the store, then fully parse
 //	plugins := store.Load()
-//	pipelines, err := parser.Parse(sources, plugins)
+//	pipelines, err := parser.Parse(entry, parse.OSLoader, plugins)
 type Parser interface {
-	// Plugins extracts plugin declarations. It must not require loaded
-	// plugins or evaluate anything beyond plugin declaration syntax.
-	Plugins(sources []Source) ([]Plugin, error)
+	// Plugins extracts every plugin{} declaration reachable from entry,
+	// following import{} blocks transitively. It must not require loaded
+	// plugins or evaluate anything beyond plugin/import declaration
+	// syntax.
+	Plugins(entry string, load Loader) ([]Plugin, error)
 
-	// Parse ingests sources and resolves everything needed to build
-	// pipelines. All parser-specific state (eval contexts, AST nodes)
-	// stays behind the Pipelines and the sdk.ConfigBlocks inside them.
-	Parse(sources []Source, plugins []sdk.Plugin) (map[string]Pipeline, error)
+	// Parse resolves entry — and its transitive imports — against the
+	// given plugins, and returns every pipeline{} block declared directly
+	// in entry (pipelines reachable only via import don't run on their
+	// own; they're data for entry's pipelines to reuse). All
+	// parser-specific state (eval contexts, AST nodes) stays behind the
+	// Pipelines and the sdk.ConfigBlocks inside them.
+	Parse(entry string, load Loader, plugins []sdk.Plugin) (map[string]Pipeline, error)
 }

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -17,14 +17,14 @@ type Plugin struct {
 // plugin declarations live in the same sources being parsed:
 //
 //	// init: extract specs (following imports), build the store, lock it
-//	specs := parser.Plugins(entry, parse.SourceFromFile)
+//	specs := parser.Plugins(entry, parse.FileLoader)
 //	locked, err := store.Build(specs)
 //	plugins.WriteLock(entry, &plugins.Lock{Plugins: locked})
 //
 //	// run: read the lock, load from the store, then fully parse
 //	lock, err := plugins.ReadLock(entry)
 //	loaded, err := store.Load(lock.Plugins)
-//	pipelines, err := parser.Parse(entry, parse.SourceFromFile, loaded)
+//	pipelines, err := parser.Parse(entry, parse.FileLoader, loaded)
 type Parser interface {
 	// Plugins extracts every plugin{} declaration reachable from entry,
 	// following import{} blocks transitively. It must not require loaded

--- a/parse/source.go
+++ b/parse/source.go
@@ -3,39 +3,48 @@ package parse
 import (
 	"fmt"
 	"os"
-	"path"
-	"strings"
+	"path/filepath"
 )
 
 // Source is a chunk of configuration with enough identity to attribute
 // errors back to its origin. It intentionally does not commit to being a
 // file: a producer that generates config dynamically yields the same type.
+//
+// When Source comes from a real file (via SourceFromFile / a Loader),
+// Name is a filesystem path and import{} attributes inside its Content
+// resolve relative to filepath.Dir(Name).
 type Source struct {
-	Name    string // "pipeline.psy", "remote://abc123", "stdin", ...
+	Name    string // a filesystem path, or a synthetic label ("remote://abc123", "stdin", ...)
 	Content []byte
 }
 
-// SourceFromDir collects every .psy file in directory as its own Source,
-// preserving filenames for diagnostics.
-func SourceFromDir(directory string) ([]Source, error) {
-	entries, err := os.ReadDir(directory)
+// Loader reads the source found at path. Parsers call it on demand as
+// import{} blocks are discovered, rather than requiring every reachable
+// file to be read upfront. Keeping this as an injected function (instead
+// of parse/hcl reading files directly) preserves Source's format-agnostic
+// design and keeps import resolution unit-testable against in-memory
+// fixtures.
+type Loader func(path string) (Source, error)
+
+// SourceFromFile reads a single .psy file as a Source, keyed by its path.
+func SourceFromFile(path string) (Source, error) {
+	content, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read files in %s: %w", directory, err)
+		return Source{}, fmt.Errorf("failed reading %s: %w", path, err)
 	}
+	return Source{Name: path, Content: content}, nil
+}
 
-	sources := make([]Source, 0, len(entries))
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".psy") {
-			continue
-		}
+// OSLoader is the default Loader, backed by the local filesystem.
+func OSLoader(path string) (Source, error) { return SourceFromFile(path) }
 
-		content, err := os.ReadFile(path.Join(directory, entry.Name()))
-		if err != nil {
-			return nil, fmt.Errorf("failed reading %s: %w", entry.Name(), err)
-		}
-
-		sources = append(sources, Source{Name: entry.Name(), Content: content})
+// ResolveImportPath resolves an import{} path attribute (importPath)
+// relative to the file that declared it (fromFile), and normalizes the
+// result. Parsers use this so the same logical file always produces the
+// same path string regardless of which importer reached it.
+func ResolveImportPath(fromFile, importPath string) string {
+	if filepath.IsAbs(importPath) {
+		return filepath.Clean(importPath)
 	}
-
-	return sources, nil
+	return filepath.Clean(filepath.Join(filepath.Dir(fromFile), importPath))
 }

--- a/parse/source.go
+++ b/parse/source.go
@@ -27,6 +27,9 @@ type Source struct {
 type Loader func(path string) (Source, error)
 
 // SourceFromFile reads a single .psy file as a Source, keyed by its path.
+// Its signature matches Loader, so it can be passed anywhere a Loader is
+// expected — the real, filesystem-backed one, as opposed to a fixture-based
+// Loader a test might use instead.
 func SourceFromFile(path string) (Source, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -34,9 +37,6 @@ func SourceFromFile(path string) (Source, error) {
 	}
 	return Source{Name: path, Content: content}, nil
 }
-
-// OSLoader is the default Loader, backed by the local filesystem.
-func OSLoader(path string) (Source, error) { return SourceFromFile(path) }
 
 // ResolveImportPath resolves an import{} path attribute (importPath)
 // relative to the file that declared it (fromFile), and normalizes the

--- a/parse/source.go
+++ b/parse/source.go
@@ -10,9 +10,9 @@ import (
 // errors back to its origin. It intentionally does not commit to being a
 // file: a producer that generates config dynamically yields the same type.
 //
-// When Source comes from a real file (via SourceFromFile / a Loader),
-// Name is a filesystem path and import{} attributes inside its Content
-// resolve relative to filepath.Dir(Name).
+// When Source comes from a real file (via FileLoader / a Loader), Name is
+// a filesystem path and import{} attributes inside its Content resolve
+// relative to filepath.Dir(Name).
 type Source struct {
 	Name    string // a filesystem path, or a synthetic label ("remote://abc123", "stdin", ...)
 	Content []byte
@@ -23,14 +23,15 @@ type Source struct {
 // file to be read upfront. Keeping this as an injected function (instead
 // of parse/hcl reading files directly) preserves Source's format-agnostic
 // design and keeps import resolution unit-testable against in-memory
-// fixtures.
+// fixtures. Implementations are named <Kind>Loader — FileLoader is the
+// real, filesystem-backed one; a test can supply its own (e.g. backed by
+// an in-memory map) wherever a Loader is expected.
 type Loader func(path string) (Source, error)
 
-// SourceFromFile reads a single .psy file as a Source, keyed by its path.
-// Its signature matches Loader, so it can be passed anywhere a Loader is
-// expected — the real, filesystem-backed one, as opposed to a fixture-based
-// Loader a test might use instead.
-func SourceFromFile(path string) (Source, error) {
+// FileLoader is the Loader that reads from the local filesystem: it reads
+// path as a single .psy file and returns it as a Source keyed by that
+// path.
+func FileLoader(path string) (Source, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return Source{}, fmt.Errorf("failed reading %s: %w", path, err)

--- a/plugins/fetch.go
+++ b/plugins/fetch.go
@@ -32,8 +32,9 @@ func pluginKind(spec parse.Plugin) int {
 }
 
 // fetcher is an ephemeral helper created by Store.Build. It holds the
-// temporary clone directory alongside the store so it can delegate all
-// persistent-path questions back to the store.
+// temporary clone/build directory; every binary it produces is handed to
+// the store to be content-addressed before fetch returns — the store
+// itself is never told a plugin's name, only its bytes.
 type fetcher struct {
 	store  *Store
 	tmpDir string
@@ -47,13 +48,16 @@ func (f *fetcher) cleanup() {
 	os.RemoveAll(f.tmpDir)
 }
 
+// build compiles codePath into a temporary .so. It never writes directly
+// into the store — the store only knows binaries by content hash, which
+// isn't known until after the build produces bytes to hash.
 func (f *fetcher) build(codePath string, spec parse.Plugin) (string, error) {
-	soPath := f.store.soPath(spec.Name)
-	cmd := exec.Command("go", "build", "-C", codePath, "-o", soPath, "-buildmode", "plugin")
+	tmpOut := filepath.Join(f.tmpDir, spec.Name+".so")
+	cmd := exec.Command("go", "build", "-C", codePath, "-o", tmpOut, "-buildmode", "plugin")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("failed to build %s: %w\noutput: %s", codePath, err, out)
 	}
-	return soPath, nil
+	return tmpOut, nil
 }
 
 func (f *fetcher) clone(spec parse.Plugin) (string, error) {
@@ -69,6 +73,12 @@ func (f *fetcher) clone(spec parse.Plugin) (string, error) {
 	return cloneDir, nil
 }
 
+// fetch resolves spec (building it first if it's source code) and
+// content-addresses the resulting binary into the store, returning its
+// hash. A local .so source is read and stored as-is, relative to the
+// current working directory same as any other file argument — the store
+// no longer needs it to be absolute since it only reads it once, here, to
+// copy its bytes in.
 func (f *fetcher) fetch(spec parse.Plugin) (string, error) {
 	switch pluginKind(spec) {
 	case pluginLocal:
@@ -77,19 +87,23 @@ func (f *fetcher) fetch(spec parse.Plugin) (string, error) {
 			return "", err
 		}
 		if stat.IsDir() {
-			return f.build(spec.Source, spec)
+			built, err := f.build(spec.Source, spec)
+			if err != nil {
+				return "", err
+			}
+			return f.store.storeBinary(built)
 		}
-		soPath := spec.Source
-		if !filepath.IsAbs(soPath) {
-			soPath = filepath.Join(f.store.pluginsDir(), soPath)
-		}
-		return filepath.Abs(soPath)
+		return f.store.storeBinary(spec.Source)
 	case pluginRemote:
 		cloneDir, err := f.clone(spec)
 		if err != nil {
 			return "", err
 		}
-		return f.build(cloneDir, spec)
+		built, err := f.build(cloneDir, spec)
+		if err != nil {
+			return "", err
+		}
+		return f.store.storeBinary(built)
 	default:
 		return "", fmt.Errorf("unable to find a suitable way to fetch %s: %#v", spec.Name, spec)
 	}

--- a/plugins/fetch.go
+++ b/plugins/fetch.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/gastrodon/psyduck/parse"
 )
@@ -73,38 +74,69 @@ func (f *fetcher) clone(spec parse.Plugin) (string, error) {
 	return cloneDir, nil
 }
 
+// resolveRef reports the most specific git reference HEAD actually
+// resolves to in cloneDir, after cloning and any requested checkout:
+// a branch (refs/heads/<name>) if HEAD is symbolic, else a tag
+// (refs/tags/<name>) if HEAD exactly matches one, else the commit's full
+// SHA. Called unconditionally for every remote plugin — even one with no
+// `tag` attribute still lands on some real commit, and that's what gets
+// recorded.
+func resolveRef(cloneDir string) (string, error) {
+	if out, err := exec.Command("git", "-C", cloneDir, "symbolic-ref", "-q", "HEAD").CombinedOutput(); err == nil {
+		return strings.TrimSpace(string(out)), nil
+	}
+
+	if out, err := exec.Command("git", "-C", cloneDir, "describe", "--tags", "--exact-match", "HEAD").CombinedOutput(); err == nil {
+		return "refs/tags/" + strings.TrimSpace(string(out)), nil
+	}
+
+	out, err := exec.Command("git", "-C", cloneDir, "rev-parse", "HEAD").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve HEAD in %s: %w\noutput: %s", cloneDir, err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // fetch resolves spec (building it first if it's source code) and
 // content-addresses the resulting binary into the store, returning its
-// hash. A local .so source is read and stored as-is, relative to the
-// current working directory same as any other file argument — the store
-// no longer needs it to be absolute since it only reads it once, here, to
+// hash and, for remote sources, the actual git ref that got checked out.
+// A local .so source is read and stored as-is, relative to the current
+// working directory same as any other file argument — the store no
+// longer needs it to be absolute since it only reads it once, here, to
 // copy its bytes in.
-func (f *fetcher) fetch(spec parse.Plugin) (string, error) {
+func (f *fetcher) fetch(spec parse.Plugin) (hash, resolve string, err error) {
 	switch pluginKind(spec) {
 	case pluginLocal:
 		stat, err := os.Stat(spec.Source)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		if stat.IsDir() {
 			built, err := f.build(spec.Source, spec)
 			if err != nil {
-				return "", err
+				return "", "", err
 			}
-			return f.store.storeBinary(built)
+			hash, err := f.store.storeBinary(built)
+			return hash, "", err
 		}
-		return f.store.storeBinary(spec.Source)
+		hash, err := f.store.storeBinary(spec.Source)
+		return hash, "", err
 	case pluginRemote:
 		cloneDir, err := f.clone(spec)
 		if err != nil {
-			return "", err
+			return "", "", err
+		}
+		resolve, err := resolveRef(cloneDir)
+		if err != nil {
+			return "", "", err
 		}
 		built, err := f.build(cloneDir, spec)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
-		return f.store.storeBinary(built)
+		hash, err := f.store.storeBinary(built)
+		return hash, resolve, err
 	default:
-		return "", fmt.Errorf("unable to find a suitable way to fetch %s: %#v", spec.Name, spec)
+		return "", "", fmt.Errorf("unable to find a suitable way to fetch %s: %#v", spec.Name, spec)
 	}
 }

--- a/plugins/fetch_test.go
+++ b/plugins/fetch_test.go
@@ -1,6 +1,10 @@
 package plugins
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastrodon/psyduck/parse"
@@ -29,4 +33,74 @@ func TestPluginKind(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mustGit runs a git command in dir, failing the test on error and
+// returning trimmed stdout+stderr.
+func mustGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestResolveRef exercises the three cases resolveRef distinguishes,
+// against a real local repo: HEAD on a branch, HEAD exactly at a tag, and
+// detached at a bare commit (what checking out a raw SHA leaves you at).
+func TestResolveRef(t *testing.T) {
+	dir := t.TempDir()
+	mustGit(t, dir, "init", "-q", "-b", "main")
+	mustGit(t, dir, "config", "user.email", "test@test.com")
+	mustGit(t, dir, "config", "user.name", "test")
+
+	write := func(content string) {
+		if err := os.WriteFile(filepath.Join(dir, "f"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write("a")
+	mustGit(t, dir, "add", "f")
+	mustGit(t, dir, "commit", "-q", "-m", "first")
+	mustGit(t, dir, "tag", "v1.0.0")
+
+	write("b")
+	mustGit(t, dir, "commit", "-q", "-am", "second")
+	secondSHA := mustGit(t, dir, "rev-parse", "HEAD") // untagged, so a real fallback case
+	mustGit(t, dir, "checkout", "-q", "-b", "feature")
+
+	t.Run("branch", func(t *testing.T) {
+		mustGit(t, dir, "checkout", "-q", "feature")
+		ref, err := resolveRef(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ref != "refs/heads/feature" {
+			t.Errorf("ref = %q, want refs/heads/feature", ref)
+		}
+	})
+
+	t.Run("tag", func(t *testing.T) {
+		mustGit(t, dir, "checkout", "-q", "v1.0.0")
+		ref, err := resolveRef(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ref != "refs/tags/v1.0.0" {
+			t.Errorf("ref = %q, want refs/tags/v1.0.0", ref)
+		}
+	})
+
+	t.Run("detached sha", func(t *testing.T) {
+		mustGit(t, dir, "checkout", "-q", secondSHA)
+		ref, err := resolveRef(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ref != secondSHA {
+			t.Errorf("ref = %q, want %q", ref, secondSHA)
+		}
+	})
 }

--- a/plugins/load_test.go
+++ b/plugins/load_test.go
@@ -5,13 +5,14 @@ package plugins
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/psyduck-etl/sdk"
+
+	"github.com/gastrodon/psyduck/parse"
 )
 
 // jsonBlock is a ConfigBlock backed by a JSON blob, mirroring the SDK's own
@@ -27,34 +28,26 @@ func (b jsonBlock) Decode(dst any) error {
 	return json.Unmarshal(b.data, dst)
 }
 
-// buildExamplePlugin compiles cmd/example-plugin to a .so at outPath. Tests
-// run from the package directory, so the module root is one level up.
-func buildExamplePlugin(t *testing.T, outPath string) {
+// examplePluginDir locates cmd/example-plugin. Tests run from the package
+// directory, so the module root is one level up.
+func examplePluginDir(t *testing.T) string {
 	t.Helper()
 	src, err := filepath.Abs("../cmd/example-plugin")
 	if err != nil {
 		t.Fatalf("abs example plugin path: %v", err)
 	}
-	cmd := exec.Command("go", "build", "-C", src, "-o", outPath, "-buildmode", "plugin")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("build example plugin: %v\n%s", err, out)
-	}
+	return src
 }
 
 func TestLoad_Integration(t *testing.T) {
 	store := NewStore(t.TempDir())
-	if err := os.MkdirAll(store.pluginsDir(), 0o755); err != nil {
-		t.Fatalf("mkdir plugins: %v", err)
+
+	locked, err := store.Build([]parse.Plugin{{Name: "example-plugin", Source: examplePluginDir(t)}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
 	}
 
-	soPath := store.soPath("example-plugin")
-	buildExamplePlugin(t, soPath)
-
-	if err := store.writeManifest(map[string]string{"example-plugin": soPath}); err != nil {
-		t.Fatalf("writeManifest: %v", err)
-	}
-
-	plugins, err := store.Load()
+	plugins, err := store.Load(locked)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -120,13 +113,35 @@ Loop:
 	}
 }
 
-func TestLoad_MissingPlugin(t *testing.T) {
+func TestBuild_DedupesSharedHash(t *testing.T) {
+	// Two different plugin names built from the same source dir produce
+	// byte-identical .so files and should collapse to one stored binary.
 	store := NewStore(t.TempDir())
-	if err := store.writeManifest(map[string]string{"missing-plugin": "/nonexistent/plugin.so"}); err != nil {
-		t.Fatalf("writeManifest: %v", err)
+
+	locked, err := store.Build([]parse.Plugin{
+		{Name: "a", Source: examplePluginDir(t)},
+		{Name: "b", Source: examplePluginDir(t)},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if locked["a"].Hash == "" || locked["a"].Hash != locked["b"].Hash {
+		t.Fatalf("want matching non-empty hashes for identical builds, got %#v", locked)
 	}
 
-	_, err := store.Load()
+	entries, err := os.ReadDir(store.pluginsDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("want exactly 1 stored binary, got %d", len(entries))
+	}
+}
+
+func TestLoad_MissingPlugin(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	_, err := store.Load(map[string]LockedPlugin{"missing-plugin": {Hash: "deadbeef"}})
 	if err == nil {
 		t.Fatal("Load succeeded, want error")
 	}
@@ -137,23 +152,40 @@ func TestLoad_MissingPlugin(t *testing.T) {
 
 func TestLoad_InvalidPluginFile(t *testing.T) {
 	store := NewStore(t.TempDir())
-	if err := os.MkdirAll(store.pluginsDir(), 0o755); err != nil {
-		t.Fatalf("mkdir plugins: %v", err)
+
+	hash, err := store.storeBinary(mustWriteTemp(t, "not a real plugin"))
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	badPath := filepath.Join(store.pluginsDir(), "bad.so")
-	if err := os.WriteFile(badPath, nil, 0o644); err != nil {
-		t.Fatalf("write bad plugin: %v", err)
-	}
-	if err := store.writeManifest(map[string]string{"bad-plugin": badPath}); err != nil {
-		t.Fatalf("writeManifest: %v", err)
-	}
-
-	_, err := store.Load()
+	_, err = store.Load(map[string]LockedPlugin{"bad-plugin": {Hash: hash}})
 	if err == nil {
 		t.Fatal("Load succeeded, want error")
 	}
 	if !strings.Contains(err.Error(), "bad-plugin") {
+		t.Errorf("error should mention plugin name, got: %v", err)
+	}
+}
+
+func TestLoad_HashMismatch(t *testing.T) {
+	store := NewStore(t.TempDir())
+
+	hash, err := store.storeBinary(mustWriteTemp(t, "original content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Corrupt the stored binary after the fact — Load must catch the drift
+	// rather than silently opening whatever's on disk.
+	if err := os.WriteFile(store.hashPath(hash), []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.Load(map[string]LockedPlugin{"corrupted": {Hash: hash}})
+	if err == nil {
+		t.Fatal("Load succeeded over a tampered binary, want a hash-mismatch error")
+	}
+	if !strings.Contains(err.Error(), "corrupted") {
 		t.Errorf("error should mention plugin name, got: %v", err)
 	}
 }

--- a/plugins/lock.go
+++ b/plugins/lock.go
@@ -9,12 +9,20 @@ import (
 )
 
 // LockedPlugin is one plugin's resolved, content-addressed entry in a
-// lock file: where it came from, and the hash of the exact .so bytes that
-// were built from it.
+// lock file: where it came from, the git ref that was actually checked
+// out (empty for local, non-git sources), and the hash of the exact .so
+// bytes that were built from it.
+//
+// Resolve is always the *actual* ref init resolved at build time — a
+// branch (refs/heads/<name>), a tag (refs/tags/<name>), or, if neither
+// applies, the commit's full SHA — never just an echo of whatever the
+// plugin{} block's optional `tag` attribute said. That's true whether or
+// not `tag` was set: an unset tag still checks out (and records) whatever
+// the default branch resolved to at init time.
 type LockedPlugin struct {
-	Source string `json:"source"`
-	Tag    string `json:"tag,omitempty"`
-	Hash   string `json:"hash"`
+	Source  string `json:"source"`
+	Resolve string `json:"resolve,omitempty"`
+	Hash    string `json:"hash"`
 }
 
 // Lock is the full contents of a <file>.lock: every plugin (deduplicated

--- a/plugins/lock.go
+++ b/plugins/lock.go
@@ -1,0 +1,64 @@
+package plugins
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// LockedPlugin is one plugin's resolved, content-addressed entry in a
+// lock file: where it came from, and the hash of the exact .so bytes that
+// were built from it.
+type LockedPlugin struct {
+	Source string `json:"source"`
+	Tag    string `json:"tag,omitempty"`
+	Hash   string `json:"hash"`
+}
+
+// Lock is the full contents of a <file>.lock: every plugin (deduplicated
+// by name) reachable from that file's import closure.
+type Lock struct {
+	Plugins map[string]LockedPlugin `json:"plugins"`
+}
+
+// LockPath returns the lock file path for a .psy file: path/to/name.psy ->
+// path/to/name.lock, sitting next to the source file it locks.
+func LockPath(file string) string {
+	return strings.TrimSuffix(file, ".psy") + ".lock"
+}
+
+// ReadLock reads the lock file for file. A missing lock file is reported
+// as a specific, actionable error rather than treated as "no plugins" —
+// every file that's run must have been explicitly init'd first.
+func ReadLock(file string) (*Lock, error) {
+	path := LockPath(file)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%s: no lock file — run `psyduck init %s` first", file, file)
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
+	lock := &Lock{}
+	if err := json.Unmarshal(data, lock); err != nil {
+		return nil, fmt.Errorf("%s: malformed lock file: %w", path, err)
+	}
+	if lock.Plugins == nil {
+		lock.Plugins = map[string]LockedPlugin{}
+	}
+	return lock, nil
+}
+
+// WriteLock writes the lock file for file, formatted for readability since
+// lock files are meant to be committed and diffed.
+func WriteLock(file string, lock *Lock) error {
+	data, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(LockPath(file), data, 0o644)
+}

--- a/plugins/lock.go
+++ b/plugins/lock.go
@@ -13,16 +13,16 @@ import (
 // out (empty for local, non-git sources), and the hash of the exact .so
 // bytes that were built from it.
 //
-// Resolve is always the *actual* ref init resolved at build time — a
-// branch (refs/heads/<name>), a tag (refs/tags/<name>), or, if neither
-// applies, the commit's full SHA — never just an echo of whatever the
-// plugin{} block's optional `tag` attribute said. That's true whether or
-// not `tag` was set: an unset tag still checks out (and records) whatever
-// the default branch resolved to at init time.
+// Ref is always the *actual* ref init resolved at build time — a branch
+// (refs/heads/<name>), a tag (refs/tags/<name>), or, if neither applies,
+// the commit's full SHA — never just an echo of whatever the plugin{}
+// block's optional `tag` attribute said. That's true whether or not `tag`
+// was set: an unset tag still checks out (and records) whatever the
+// default branch resolved to at init time.
 type LockedPlugin struct {
-	Source  string `json:"source"`
-	Resolve string `json:"resolve,omitempty"`
-	Hash    string `json:"hash"`
+	Source string `json:"source"`
+	Ref    string `json:"ref,omitempty"`
+	Hash   string `json:"hash"`
 }
 
 // Lock is the full contents of a <file>.lock: every plugin (deduplicated

--- a/plugins/store.go
+++ b/plugins/store.go
@@ -1,8 +1,8 @@
 package plugins
 
 import (
-	"encoding/json"
-	"errors"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,9 +13,11 @@ import (
 	"github.com/gastrodon/psyduck/parse"
 )
 
-// Store represents the .psyduck/ workspace directory: the single source of
-// truth for where plugin binaries live, where the manifest is written, and
-// how plugins are loaded at run time.
+// Store represents the .psyduck/ directory: content-addressed storage for
+// built plugin binaries, keyed by the sha256 of their own bytes. The
+// mapping from plugin name to hash lives in a separate per-file lock file
+// (see lock.go) — the store itself only knows how to place and retrieve
+// binaries by hash, so the same store can back any number of lock files.
 type Store struct {
 	root string
 }
@@ -23,7 +25,7 @@ type Store struct {
 func NewStore(root string) *Store {
 	// The root must be absolute: relative paths would silently misbehave in
 	// fetcher.build (`go build -C` resolves -o relative to the -C directory,
-	// not our cwd) and would bake cwd-dependent paths into the manifest.
+	// not our cwd).
 	abs, err := filepath.Abs(root)
 	if err != nil {
 		// Abs only fails if the cwd is undeterminable; keep the given root.
@@ -36,74 +38,73 @@ func (s *Store) pluginsDir() string {
 	return filepath.Join(s.root, "plugins")
 }
 
-func (s *Store) manifestPath() string {
-	return filepath.Join(s.root, "plugin.json")
+func (s *Store) hashPath(hash string) string {
+	return filepath.Join(s.pluginsDir(), hash+".so")
 }
 
-func (s *Store) soPath(name string) string {
-	return filepath.Join(s.pluginsDir(), name+".so")
-}
-
-func (s *Store) readManifest() (map[string]string, error) {
-	data, err := os.ReadFile(s.manifestPath())
+// storeBinary content-addresses the file at path into the store: hashes
+// its bytes and writes them to <hash>.so. It always writes, even if a
+// file already exists at that hash path — the expensive work (build or
+// clone) already happened by the time storeBinary is called, so skipping
+// the write would only save one cheap copy at the cost of never
+// self-healing a hash slot whose on-disk content has drifted (e.g. been
+// tampered with, or corrupted) from what its filename promises. Two specs
+// that build to identical bytes still dedupe, since they land on the same
+// hash path with the same (correct) content either way. Returns the hash.
+func (s *Store) storeBinary(path string) (string, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return map[string]string{}, nil
-		}
-		return nil, fmt.Errorf("failed to read plugin manifest: %w", err)
+		return "", fmt.Errorf("failed to read plugin binary: %w", err)
 	}
 
-	m := make(map[string]string)
-	if err := json.Unmarshal(data, &m); err != nil {
-		return nil, fmt.Errorf("failed to decode plugin manifest: %w", err)
-	}
-	return m, nil
-}
+	sum := sha256.Sum256(data)
+	hash := hex.EncodeToString(sum[:])
+	dest := s.hashPath(hash)
 
-func (s *Store) writeManifest(m map[string]string) error {
-	b, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(s.manifestPath(), b, 0o644)
-}
-
-// Build clones and compiles the declared plugins, writing the name → .so path
-// manifest to the store's manifest file. Used by the init command.
-func (s *Store) Build(specs []parse.Plugin) error {
 	if err := os.MkdirAll(s.pluginsDir(), os.ModeDir|os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create plugins dir: %w", err)
+		return "", fmt.Errorf("failed to create plugins dir: %w", err)
 	}
+	if err := os.WriteFile(dest, data, 0o644); err != nil {
+		return "", fmt.Errorf("failed to store plugin binary: %w", err)
+	}
+	return hash, nil
+}
 
+// Build clones and compiles every declared plugin, content-addressing
+// each resulting binary into the store. It returns the lock data for the
+// caller to write next to the source file being init'd — the store
+// itself holds no name-based state, so nothing here depends on which
+// file the specs came from.
+func (s *Store) Build(specs []parse.Plugin) (map[string]LockedPlugin, error) {
 	tmpDir, err := os.MkdirTemp("", "psyduck-plugin-*")
 	if err != nil {
-		return fmt.Errorf("failed to make temp dir: %w", err)
+		return nil, fmt.Errorf("failed to make temp dir: %w", err)
 	}
 	f := &fetcher{store: s, tmpDir: tmpDir}
 	defer f.cleanup()
 
-	collected := make(map[string]string, len(specs))
+	locked := make(map[string]LockedPlugin, len(specs))
 	for _, spec := range specs {
-		loc, err := f.fetch(spec)
+		hash, err := f.fetch(spec)
 		if err != nil {
-			return fmt.Errorf("unable to fetch %s: %w", spec.Name, err)
+			return nil, fmt.Errorf("unable to fetch %s: %w", spec.Name, err)
 		}
-		collected[spec.Name] = loc
+		locked[spec.Name] = LockedPlugin{Source: spec.Source, Tag: spec.Tag, Hash: hash}
 	}
-	return s.writeManifest(collected)
+	return locked, nil
 }
 
-// Load reads the manifest and opens every plugin listed in it.
-// A missing manifest is not an error — it means no plugins have been built,
-// which is valid for stdlib-only pipelines.
-func (s *Store) Load() ([]sdk.Plugin, error) {
-	manifest, err := s.readManifest()
-	if err != nil {
-		return nil, err
-	}
-
-	loaded := make([]sdk.Plugin, 0, len(manifest))
-	for name, soPath := range manifest {
+// Load opens every plugin recorded in locked, verifying each binary's
+// content still matches its locked hash before opening it — catching a
+// store that's missing, corrupted, or drifted out of sync with the lock
+// file it's supposed to satisfy.
+func (s *Store) Load(locked map[string]LockedPlugin) ([]sdk.Plugin, error) {
+	loaded := make([]sdk.Plugin, 0, len(locked))
+	for name, entry := range locked {
+		soPath := s.hashPath(entry.Hash)
+		if err := verifyHash(soPath, entry.Hash); err != nil {
+			return nil, fmt.Errorf("plugin %s: %w", name, err)
+		}
 		p, err := loadBinary(name, soPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load plugin %s: %w", name, err)
@@ -111,6 +112,19 @@ func (s *Store) Load() ([]sdk.Plugin, error) {
 		loaded = append(loaded, p)
 	}
 	return loaded, nil
+}
+
+// verifyHash confirms the file at path still hashes to want.
+func verifyHash(path, want string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("binary missing at %s (run init again): %w", path, err)
+	}
+	sum := sha256.Sum256(data)
+	if got := hex.EncodeToString(sum[:]); got != want {
+		return fmt.Errorf("hash mismatch at %s: locked %s, found %s (run init again)", path, want, got)
+	}
+	return nil
 }
 
 // loadBinary opens the shared object at soPath and returns the sdk.Plugin

--- a/plugins/store.go
+++ b/plugins/store.go
@@ -89,7 +89,7 @@ func (s *Store) Build(specs []parse.Plugin) (map[string]LockedPlugin, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch %s: %w", spec.Name, err)
 		}
-		locked[spec.Name] = LockedPlugin{Source: spec.Source, Resolve: resolve, Hash: hash}
+		locked[spec.Name] = LockedPlugin{Source: spec.Source, Ref: resolve, Hash: hash}
 	}
 	return locked, nil
 }

--- a/plugins/store.go
+++ b/plugins/store.go
@@ -85,11 +85,11 @@ func (s *Store) Build(specs []parse.Plugin) (map[string]LockedPlugin, error) {
 
 	locked := make(map[string]LockedPlugin, len(specs))
 	for _, spec := range specs {
-		hash, err := f.fetch(spec)
+		hash, resolve, err := f.fetch(spec)
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch %s: %w", spec.Name, err)
 		}
-		locked[spec.Name] = LockedPlugin{Source: spec.Source, Tag: spec.Tag, Hash: hash}
+		locked[spec.Name] = LockedPlugin{Source: spec.Source, Resolve: resolve, Hash: hash}
 	}
 	return locked, nil
 }

--- a/plugins/store_test.go
+++ b/plugins/store_test.go
@@ -1,10 +1,8 @@
 package plugins
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 )
 
@@ -25,12 +23,11 @@ func TestStorePaths(t *testing.T) {
 	store := NewStore(root)
 
 	cases := []struct {
-		name     string
+		name      string
 		got, want string
 	}{
 		{"pluginsDir", store.pluginsDir(), filepath.Join(root, "plugins")},
-		{"manifestPath", store.manifestPath(), filepath.Join(root, "plugin.json")},
-		{"soPath", store.soPath("myplugin"), filepath.Join(root, "plugins", "myplugin.so")},
+		{"hashPath", store.hashPath("deadbeef"), filepath.Join(root, "plugins", "deadbeef.so")},
 	}
 	for _, c := range cases {
 		if c.got != c.want {
@@ -39,51 +36,70 @@ func TestStorePaths(t *testing.T) {
 	}
 }
 
-func TestReadManifest_MissingReturnsEmpty(t *testing.T) {
+func TestStoreBinary_ContentAddressed(t *testing.T) {
 	store := NewStore(t.TempDir())
-	m, err := store.readManifest()
-	if err != nil {
-		t.Fatalf("readManifest: %v", err)
+
+	src := filepath.Join(t.TempDir(), "plugin.so")
+	if err := os.WriteFile(src, []byte("fake plugin bytes"), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	if len(m) != 0 {
-		t.Errorf("manifest = %v, want empty", m)
+
+	hash, err := store.storeBinary(src)
+	if err != nil {
+		t.Fatalf("storeBinary: %v", err)
+	}
+	if hash == "" {
+		t.Fatal("storeBinary returned empty hash")
+	}
+
+	got, err := os.ReadFile(store.hashPath(hash))
+	if err != nil {
+		t.Fatalf("stored binary not found at hash path: %v", err)
+	}
+	if string(got) != "fake plugin bytes" {
+		t.Errorf("stored content = %q, want %q", got, "fake plugin bytes")
 	}
 }
 
-func TestReadManifest_MalformedErrors(t *testing.T) {
+func TestStoreBinary_DedupesIdenticalContent(t *testing.T) {
 	store := NewStore(t.TempDir())
-	if err := os.WriteFile(store.manifestPath(), []byte(`{invalid`), 0o644); err != nil {
-		t.Fatalf("write malformed manifest: %v", err)
+
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.so")
+	b := filepath.Join(dir, "b.so")
+	if err := os.WriteFile(a, []byte("same bytes"), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	if _, err := store.readManifest(); err == nil {
-		t.Error("readManifest on malformed JSON: want error, got nil")
+	if err := os.WriteFile(b, []byte("same bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hashA, err := store.storeBinary(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hashB, err := store.storeBinary(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hashA != hashB {
+		t.Errorf("identical content hashed differently: %q vs %q", hashA, hashB)
+	}
+
+	entries, err := os.ReadDir(store.pluginsDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("want exactly 1 stored binary after dedup, got %d", len(entries))
 	}
 }
 
-func TestManifest_RoundTrip(t *testing.T) {
-	store := NewStore(t.TempDir())
-	want := map[string]string{
-		"plugin1": "/path/to/plugin1.so",
-		"plugin2": "/path/to/plugin2.so",
+func mustWriteTemp(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "plugin.so")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	if err := store.writeManifest(want); err != nil {
-		t.Fatalf("writeManifest: %v", err)
-	}
-	got, err := store.readManifest()
-	if err != nil {
-		t.Fatalf("readManifest: %v", err)
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("manifest = %v, want %v", got, want)
-	}
-
-	// On-disk format is JSON — users may inspect plugin.json directly.
-	data, err := os.ReadFile(store.manifestPath())
-	if err != nil {
-		t.Fatalf("read manifest file: %v", err)
-	}
-	var parsed map[string]string
-	if err := json.Unmarshal(data, &parsed); err != nil {
-		t.Errorf("manifest on disk is not valid JSON: %v", err)
-	}
+	return path
 }


### PR DESCRIPTION
This PR restructures psyduck's configuration parsing and standard library into a cleaner, more modular architecture.

## Summary
The codebase has been reorganized to separate concerns between HCL parsing, plugin management, and the standard library. The old `configure/` package has been replaced with a new `parse/` package that provides format-agnostic interfaces, with HCL-specific logic isolated in `parse/hcl/`. The standard library has been significantly expanded with new transformers, producers, and consumers organized by domain.

## Key Changes

**Parser Refactoring:**
- Removed `configure/` package entirely (parse.go, read.go, resources.go, pipelines.go, plugin.go, eval_ctx.go, model.go, decode_*.go)
- Created new `parse/` package with format-agnostic interfaces (Parser, Resource, Plugin, Source, Loader)
- Implemented `parse/hcl/` package with HCL-specific parsing logic (hcl.go, block.go, context.go, resource.go, import.go)
- Added comprehensive HCL parser tests (hcl_test.go with 740 lines)

**Plugin Management:**
- Created new `plugins/` package to handle plugin loading and storage (load.go, store.go, fetch.go)
- Plugins are now loaded from a `.psyduck/` workspace directory with manifest tracking
- Added plugin loading tests for local and remote plugins

**Standard Library Expansion:**
- Created `stdlib/data/` package with abstract data model (value.go, codec.go, continuous.go, discrete.go, pattern.go, walk.go, slice.go, scalar.go, onerror.go)
- Created `stdlib/transport/` package for shared I/O machinery (frame.go, location.go, http.go)
- Created `stdlib/flow/` package for pipeline flow control (flow.go with rate limiting and gates)
- Expanded transformers: text.go, shape.go, keyed.go, continuous.go, jq.go, filter.go, render.go, codec.go, dev.go
- Expanded producers: file.go, listen.go, socket.go, request.go, http_listen.go, dev.go
- Expanded consumers: file.go, socket.go, request.go
- Removed old transformers: transpose.go, zoom.go, snippet.go, sprintf.go, wait.go
- Removed old producers: increment.go

**Documentation:**
- Added comprehensive docs: hcl.md (HCL language reference), stdlib.md (standard library reference), plugins.md (plugin authoring guide), patterns.md (idiomatic usage patterns)

**Examples:**
- Replaced old example files with new .psy format examples: reshape.psy, jq.psy, text.psy, keyed.psy, select.psy, render.psy, encoding.psy, dev.psy, file-read.psy, flow.psy, http-listen.psy, http-request.psy, slicing.psy, shared.psy, meta-socket.psy
- Added example plugin template (cmd/example-plugin/main.go)

**Core Changes:**
- Updated core/build.go to use new parse package interfaces instead of configure
- Added comprehensive build and integration tests
- Updated main.go CLI to use new parser and plugin infrastructure

**Testing:**
- Added extensive test coverage: parse/hcl/hcl_test.go (740 lines), core/build_test.go, examples_test.go
- Added stdlib integration tests: broadcast_test.go, tcp_fanin_test.go, http_webhook_test.go, http_request_test.go, file_follow_test.go, socket_meta_test.go, udp_test.go
- Added stdlib unit tests: stdlib/data/data_test.go, stdlib/transform/transform_test.go, stdlib/flow/flow_test.go, stdlib/transport/frame_test.go, plugins/store_test.go, plugins/fetch_test.go

## Notable Implementation Details

- The data model uses a Value interface with Continuous (string/bytes/list) and Discrete (

https://claude.ai/code/session_01SaYwd6PvaAfNGnZPgxDT2u