### PR TITLE
Rework pipeline concurrency: context cancellation, iter.Seq2 streams, WaitGroup fan-in/out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.22'
+        go-version-file: go.mod
 
     - name: Run tests
-      run: go test ./... -v -count 1 -cover -coverprofile=coverage.out -timeout 5m
+      run: go test ./... -v -race -count 1 -cover -coverprofile=coverage.out -timeout 10m
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/cmd/example-plugin/main.go
+++ b/cmd/example-plugin/main.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/psyduck-etl/sdk"
+import (
+	"context"
+
+	"github.com/psyduck-etl/sdk"
+)
 
 // main is a no-op — required because -buildmode=plugin still needs package main.
 func main() {}
@@ -33,11 +37,15 @@ func constantProducer(parse sdk.Parser) (sdk.Producer, error) {
 		return nil, err
 	}
 	value := []byte(config.Value)
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 		for i := 0; config.Count == 0 || i < config.Count; i++ {
-			send <- value
+			select {
+			case send <- value:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}, nil
 }

--- a/cmd/example-plugin/main.go
+++ b/cmd/example-plugin/main.go
@@ -43,6 +43,7 @@ func constantProducer(parse sdk.Parser) (sdk.Producer, error) {
 		for i := 0; config.Count == 0 || i < config.Count; i++ {
 			select {
 			case send <- value:
+				continue
 			case <-ctx.Done():
 				return
 			}

--- a/core/build.go
+++ b/core/build.go
@@ -1,9 +1,9 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"sync"
 
 	"github.com/psyduck-etl/sdk"
 	"github.com/sirupsen/logrus"
@@ -12,9 +12,12 @@ import (
 	"github.com/gastrodon/psyduck/stdlib/flow"
 )
 
+// Pipeline is a runnable pipeline: producers and consumers stay separate
+// slices — RunPipeline owns merging and fan-out — and transformers are
+// pre-stacked into one function.
 type Pipeline struct {
-	Producer    sdk.Producer
-	Consumer    sdk.Consumer
+	Producers   []sdk.Producer
+	Consumers   []sdk.Consumer
 	Transformer sdk.Transformer
 	logger      *logrus.Logger
 	StopAfter   int
@@ -45,153 +48,6 @@ func pipelineLogger() *logrus.Logger {
 	return l
 }
 
-func mchan[T any](c int) []chan T {
-	g := make([]chan T, c)
-	for i := range g {
-		g[i] = make(chan T)
-	}
-	return g
-}
-
-func join[T any](group []chan T, ent *logrus.Entry) chan T {
-	joined := make(chan T)
-	closer := make(chan struct{})
-
-	go func(size int) {
-		closed, cLock := 0, new(sync.Mutex)
-		for closed < size {
-			<-closer
-			cLock.Lock()
-			closed++
-			cLock.Unlock()
-		}
-
-		ent.Trace("closing all of the groups")
-		close(joined)
-	}(len(group))
-
-	for i := range group {
-		go func(ishadow int, closer chan<- struct{}) { // goroutine forwarder for every c in group
-			for msg := range group[ishadow] {
-				joined <- msg
-			}
-
-			ent.Tracef("forwarder %d exhausted", ishadow)
-			closer <- struct{}{}
-		}(i, closer)
-	}
-
-	return joined
-}
-
-/*
-Join a collection of producers into a single in the order received
-*/
-func joinProducers(producers []sdk.Producer, logger *logrus.Logger) sdk.Producer {
-	if len(producers) == 1 {
-		return producers[0]
-	}
-
-	gData := mchan[[]byte](len(producers))
-	gErrs := mchan[error](len(producers))
-
-	tData := join(gData, logger.WithField("joined", "data"))
-	tErrs := join(gErrs, logger.WithField("joined", "errs"))
-	return func(dataOut chan<- []byte, errs chan<- error) {
-		for i := 0; i < len(producers); i++ {
-			go producers[i](gData[i], gErrs[i])
-		}
-
-	out:
-		for {
-			select {
-			case msg := <-tData:
-				if msg == nil {
-					logger.Trace("tData closed, breaking out")
-					break out
-				}
-
-				dataOut <- msg
-			case err := <-tErrs:
-				if err != nil {
-					logger.Error(err)
-					errs <- err
-				}
-			}
-		}
-
-		logger.Trace("closing dataOut")
-		close(dataOut)
-	}
-}
-
-/*
-Join a collection of consumers into a single that passes data to consumers in order
-*/
-func joinConsumers(consumers []sdk.Consumer, logger *logrus.Logger) sdk.Consumer {
-	if len(consumers) == 1 {
-		return consumers[0]
-	}
-
-	gErrs := mchan[error](len(consumers))
-	gDone := mchan[struct{}](len(consumers))
-	split := mchan[[]byte](len(consumers))
-
-	tErrs := join(gErrs, logger.WithField("joined", "errs"))
-	tDone := join(gDone, logger.WithField("joined", "done"))
-	return func(dataRecv <-chan []byte, errs chan<- error, done chan<- struct{}) {
-		for i := range split {
-			go consumers[i](split[i], gErrs[i], gDone[i])
-		}
-
-		handle := make(chan error)
-
-		go func() {
-			for msg := range dataRecv {
-				for i := range split {
-					split[i] <- msg
-					logger.Tracef("fwd to split[%d]\n", i)
-				}
-			}
-
-			close(handle)
-		}()
-
-		go func() {
-			for err := range tErrs {
-				if err != nil {
-					handle <- err
-				}
-			}
-		}()
-
-		for err := range handle {
-			if err != nil {
-				errs <- err
-			}
-		}
-
-		for i := range split {
-			logger.Tracef("closing split[%d]\n", i)
-			close(split[i])
-		}
-
-		closed, cLock := 0, new(sync.Mutex)
-		for range tDone {
-			cLock.Lock()
-			closed++
-			if closed == len(consumers) {
-				break
-			}
-
-			cLock.Unlock()
-		}
-
-		logger.Trace("closing provided done")
-		close(done)
-	}
-}
-
 /*
 Join a collection of transformers into a single that applies them in order
 */
@@ -220,10 +76,11 @@ func stackTransform(transformers []sdk.Transformer) sdk.Transformer {
 const bindChunk = 8
 
 // drain exhausts a Bindings stream, binding each against its owning plugin
-// and handing the configured instance to collect.
-func drain(bindings parse.ResourceFunc, plugins map[string]sdk.Plugin, collect func(parse.Resource, sdk.Instance)) error {
+// and handing the configured instance to collect. Draining can do real work
+// (produce-from runs its seed) so it is bounded by ctx.
+func drain(ctx context.Context, bindings parse.ResourceFunc, plugins map[string]sdk.Plugin, collect func(parse.Resource, sdk.Instance)) error {
 	for {
-		chunk, err := bindings(bindChunk)
+		chunk, err := bindings(ctx, bindChunk)
 		if err != nil {
 			return err
 		}
@@ -253,7 +110,7 @@ BuildPipeline turns a parsed pipeline description into a runnable Pipeline.
 Each binding is resolved against its owning plugin, wrapped with host-owned
 BlockMeta behavior, and joined with its siblings.
 */
-func BuildPipeline(src parse.Pipeline, plugins []sdk.Plugin) (*Pipeline, error) {
+func BuildPipeline(ctx context.Context, src parse.Pipeline, plugins []sdk.Plugin) (*Pipeline, error) {
 	logger := pipelineLogger()
 
 	lookup := make(map[string]sdk.Plugin, len(plugins))
@@ -262,7 +119,7 @@ func BuildPipeline(src parse.Pipeline, plugins []sdk.Plugin) (*Pipeline, error) 
 	}
 
 	producers := make([]sdk.Producer, 0)
-	if err := drain(src.Producers, lookup, func(b parse.Resource, instance sdk.Instance) {
+	if err := drain(ctx, src.Producers, lookup, func(b parse.Resource, instance sdk.Instance) {
 		producers = append(producers, flow.Producer(instance.Produce, b.Meta.PerMinute, 0, b.Meta.StopAfter))
 	}); err != nil {
 		return nil, err
@@ -272,7 +129,7 @@ func BuildPipeline(src parse.Pipeline, plugins []sdk.Plugin) (*Pipeline, error) 
 	}
 
 	consumers := make([]sdk.Consumer, 0)
-	if err := drain(src.Consumers, lookup, func(b parse.Resource, instance sdk.Instance) {
+	if err := drain(ctx, src.Consumers, lookup, func(b parse.Resource, instance sdk.Instance) {
 		consumers = append(consumers, flow.Consumer(instance.Consume, b.Meta.PerMinute, 0, b.Meta.StopAfter))
 	}); err != nil {
 		return nil, err
@@ -282,15 +139,15 @@ func BuildPipeline(src parse.Pipeline, plugins []sdk.Plugin) (*Pipeline, error) 
 	}
 
 	transformers := make([]sdk.Transformer, 0)
-	if err := drain(src.Transformers, lookup, func(b parse.Resource, instance sdk.Instance) {
+	if err := drain(ctx, src.Transformers, lookup, func(b parse.Resource, instance sdk.Instance) {
 		transformers = append(transformers, instance.Transform)
 	}); err != nil {
 		return nil, err
 	}
 
 	return &Pipeline{
-		Producer:    joinProducers(producers, logger),
-		Consumer:    joinConsumers(consumers, logger),
+		Producers:   producers,
+		Consumers:   consumers,
 		Transformer: stackTransform(transformers),
 		logger:      logger,
 		StopAfter:   src.StopAfter,

--- a/core/build_test.go
+++ b/core/build_test.go
@@ -26,7 +26,7 @@ func corePlugin(name string, payload []byte, count int, consumed *int, suffix st
 			Name:  "emit",
 			Kinds: sdk.PRODUCER,
 			ProvideProducer: func(sdk.Parser) (sdk.Producer, error) {
-				return func(send chan<- []byte, errs chan<- error) {
+				return func(_ context.Context, send chan<- []byte, errs chan<- error) {
 					for i := 0; i < count; i++ {
 						send <- payload
 					}
@@ -38,7 +38,7 @@ func corePlugin(name string, payload []byte, count int, consumed *int, suffix st
 			Name:  "count",
 			Kinds: sdk.CONSUMER,
 			ProvideConsumer: func(sdk.Parser) (sdk.Consumer, error) {
-				return func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+				return func(_ context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 					for range recv {
 						*consumed++
 					}

--- a/core/build_test.go
+++ b/core/build_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -113,7 +114,7 @@ func Test_drain(t *testing.T) {
 		resources[i] = r
 	}
 	seen := []string{}
-	err := drain(parse.LiteralResourceFunc(resources...), plugins, func(b parse.Resource, _ sdk.Instance) {
+	err := drain(t.Context(), parse.LiteralResourceFunc(resources...), plugins, func(b parse.Resource, _ sdk.Instance) {
 		seen = append(seen, b.Ref)
 	})
 	if err != nil {
@@ -124,20 +125,20 @@ func Test_drain(t *testing.T) {
 	}
 
 	// unknown plugin
-	err = drain(parse.LiteralResourceFunc(testResource("ghost", "emit", sdk.PRODUCER, sdk.BlockMeta{})), plugins, func(parse.Resource, sdk.Instance) {})
+	err = drain(t.Context(), parse.LiteralResourceFunc(testResource("ghost", "emit", sdk.PRODUCER, sdk.BlockMeta{})), plugins, func(parse.Resource, sdk.Instance) {})
 	if err == nil || !strings.Contains(err.Error(), `no plugin "ghost"`) {
 		t.Fatalf("want no-plugin error, got %v", err)
 	}
 
 	// bind failure (unknown resource within the plugin)
-	err = drain(parse.LiteralResourceFunc(testResource("p", "nonexistent", sdk.PRODUCER, sdk.BlockMeta{})), plugins, func(parse.Resource, sdk.Instance) {})
+	err = drain(t.Context(), parse.LiteralResourceFunc(testResource("p", "nonexistent", sdk.PRODUCER, sdk.BlockMeta{})), plugins, func(parse.Resource, sdk.Instance) {})
 	if err == nil {
 		t.Fatal("want bind error, got nil")
 	}
 
 	// stream error propagates
-	streamErr := func(int) ([]parse.Resource, error) { return nil, fmt.Errorf("stream broke") }
-	if err := drain(streamErr, plugins, func(parse.Resource, sdk.Instance) {}); err == nil || err.Error() != "stream broke" {
+	streamErr := func(context.Context, int) ([]parse.Resource, error) { return nil, fmt.Errorf("stream broke") }
+	if err := drain(t.Context(), streamErr, plugins, func(parse.Resource, sdk.Instance) {}); err == nil || err.Error() != "stream broke" {
 		t.Fatalf("want stream error, got %v", err)
 	}
 }
@@ -159,14 +160,14 @@ func Test_BuildPipeline(t *testing.T) {
 
 	src := mksrc(sdk.BlockMeta{})
 	src.StopAfter = 7
-	pipeline, err := BuildPipeline(src, []sdk.Plugin{plugin})
+	pipeline, err := BuildPipeline(t.Context(), src, []sdk.Plugin{plugin})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if pipeline.StopAfter != 7 || !pipeline.ExitOnError {
 		t.Fatalf("pipeline flags not propagated: %#v", pipeline)
 	}
-	if err := RunPipeline(pipeline); err != nil {
+	if err := RunPipeline(t.Context(), pipeline); err != nil {
 		t.Fatal(err)
 	}
 	if consumed != 5 {
@@ -175,11 +176,11 @@ func Test_BuildPipeline(t *testing.T) {
 
 	// producer meta applies: stop-after 2 of 5
 	consumed = 0
-	pipeline, err = BuildPipeline(mksrc(sdk.BlockMeta{StopAfter: 2}), []sdk.Plugin{plugin})
+	pipeline, err = BuildPipeline(t.Context(), mksrc(sdk.BlockMeta{StopAfter: 2}), []sdk.Plugin{plugin})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := RunPipeline(pipeline); err != nil {
+	if err := RunPipeline(t.Context(), pipeline); err != nil {
 		t.Fatal(err)
 	}
 	if consumed != 2 {
@@ -195,18 +196,18 @@ func Test_BuildPipeline_errors(t *testing.T) {
 	producer := parse.LiteralResourceFunc(testResource("p", "emit", sdk.PRODUCER, sdk.BlockMeta{}))
 	consumer := parse.LiteralResourceFunc(testResource("p", "count", sdk.CONSUMER, sdk.BlockMeta{}))
 
-	_, err := BuildPipeline(parse.Pipeline{Name: "x", Producers: empty, Consumers: consumer, Transformers: empty}, []sdk.Plugin{plugin})
+	_, err := BuildPipeline(t.Context(), parse.Pipeline{Name: "x", Producers: empty, Consumers: consumer, Transformers: empty}, []sdk.Plugin{plugin})
 	if err == nil || !strings.Contains(err.Error(), "no producers") {
 		t.Fatalf("want no-producers error, got %v", err)
 	}
 
-	_, err = BuildPipeline(parse.Pipeline{Name: "x", Producers: producer, Consumers: empty, Transformers: empty}, []sdk.Plugin{plugin})
+	_, err = BuildPipeline(t.Context(), parse.Pipeline{Name: "x", Producers: producer, Consumers: empty, Transformers: empty}, []sdk.Plugin{plugin})
 	if err == nil || !strings.Contains(err.Error(), "no consumers") {
 		t.Fatalf("want no-consumers error, got %v", err)
 	}
 
 	ghost := parse.LiteralResourceFunc(testResource("ghost", "emit", sdk.PRODUCER, sdk.BlockMeta{}))
-	_, err = BuildPipeline(parse.Pipeline{Name: "x", Producers: ghost, Consumers: consumer, Transformers: empty}, []sdk.Plugin{plugin})
+	_, err = BuildPipeline(t.Context(), parse.Pipeline{Name: "x", Producers: ghost, Consumers: consumer, Transformers: empty}, []sdk.Plugin{plugin})
 	if err == nil || !strings.Contains(err.Error(), `no plugin "ghost"`) {
 		t.Fatalf("want no-plugin error, got %v", err)
 	}

--- a/core/regression_test.go
+++ b/core/regression_test.go
@@ -294,3 +294,66 @@ func Test_CtxAwareProducer_LeavesNoGoroutineOnAbandon(t *testing.T) {
 	t.Fatalf("ctx-aware producer still leaked a goroutine on abandon: %d -> %d\n%s",
 		baseline, runtime.NumGoroutine(), buf[:runtime.Stack(buf, true)])
 }
+
+// Regression for the late-error drop: a producer that closes its data
+// channel and then reports an error. The error forwarder used to sweep
+// pending errors with a non-blocking default the moment all data channels
+// closed — but on an unbuffered errs channel a plugin blocked mid-send has
+// nothing "pending in the channel", so the sweep saw nothing and the error
+// was silently lost (and the plugin stayed parked on the send until
+// pipeline cancellation). The error must instead be delivered: the
+// forwarder now waits for the producer function to return before its final
+// race-free drain.
+func Test_ErrorAfterDataClose_IsDelivered(t *testing.T) {
+	producer := func(ctx context.Context, send chan<- []byte, errs chan<- error) {
+		defer close(errs)
+		send <- []byte("x")
+		close(send)
+		// Give the old sweep every chance to run first, so the drop is
+		// deterministic rather than a lucky race.
+		time.Sleep(50 * time.Millisecond)
+		select {
+		case errs <- errors.New("late error after data close"):
+		case <-ctx.Done():
+		}
+	}
+
+	var got atomic.Int64
+	err := panicSafeRun(t, &Pipeline{
+		Producers:   []sdk.Producer{producer},
+		Consumers:   []sdk.Consumer{countAll(&got)},
+		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		ExitOnError: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "late error after data close") {
+		t.Fatalf("late error was dropped: got %v", err)
+	}
+}
+
+// A producer that ignores ctx entirely and sends forever with a bare send
+// (no select on ctx.Done) violates the sdk contract and leaks its own
+// goroutine when abandoned — the engine can't prevent that. What the engine
+// must still guarantee is that RunPipeline itself returns: the abandoned
+// plugin parks, the pipeline doesn't.
+func Test_ContractViolatingProducer_EngineStillReturns(t *testing.T) {
+	misbehaving := func(_ context.Context, send chan<- []byte, errs chan<- error) {
+		for {
+			send <- []byte("x") // bare send: parks forever once abandoned
+		}
+	}
+
+	var got atomic.Int64
+	if err := panicSafeRun(t, &Pipeline{
+		Producers:   []sdk.Producer{misbehaving},
+		Consumers:   []sdk.Consumer{countAll(&got)},
+		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		StopAfter:   3,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if n := got.Load(); n != 3 {
+		t.Fatalf("want 3 delivered, got %d", n)
+	}
+	// Note: this test intentionally leaks the misbehaving producer's
+	// goroutine — that's the documented cost of violating the contract.
+}

--- a/core/regression_test.go
+++ b/core/regression_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"runtime"
 	"strings"
@@ -44,6 +45,12 @@ import (
 // #8 (produce-from seed closing without sending) is a parse-layer bug, not
 // a core-engine one; its regression test lives in
 // parse/hcl/hcl_test.go:TestParseProduceFromClosedSeed.
+//
+// sdk v0.5.1 added ctx as Producer/Consumer's first parameter, giving
+// well-behaved plugins a way to exit on cancellation instead of parking.
+// The producers below accept and deliberately ignore it — these tests exist
+// to prove the engine itself never panics or deadlocks even when a plugin
+// doesn't cooperate, not to exercise cancellation.
 
 // panicSafeRun runs RunPipeline in its own goroutine, converting any panic
 // into a clean test failure instead of crashing the whole test binary, and
@@ -90,7 +97,10 @@ func panicSafeRun(t *testing.T, p *Pipeline) error {
 func Test_LateErrorAfterExitOnError_NoPanic(t *testing.T) {
 	const lateDelay = 100 * time.Millisecond
 
-	producer := func(send chan<- []byte, errs chan<- error) {
+	// ctx is ignored on purpose: err2 must still be attempted after
+	// RunPipeline has cancelled and returned, which is exactly what a
+	// ctx-respecting producer would avoid.
+	producer := func(_ context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 		send <- []byte("x")
@@ -98,7 +108,7 @@ func Test_LateErrorAfterExitOnError_NoPanic(t *testing.T) {
 		time.Sleep(lateDelay)
 		errs <- errors.New("err2 (arrives after RunPipeline already returned)")
 	}
-	consumer := func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+	consumer := func(_ context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 		defer close(done)
 		defer close(errs)
 		for range recv {
@@ -159,21 +169,21 @@ func Test_NilMessage_DoesNotTruncateStream(t *testing.T) {
 	var got atomic.Int64
 	second := make(chan struct{})
 	producers := []sdk.Producer{
-		func(send chan<- []byte, errs chan<- error) {
+		func(_ context.Context, send chan<- []byte, errs chan<- error) {
 			defer close(send)
 			defer close(errs)
 			send <- []byte("before")
 			send <- nil
 			send <- []byte("after")
 		},
-		func(send chan<- []byte, errs chan<- error) {
+		func(_ context.Context, send chan<- []byte, errs chan<- error) {
 			defer close(send)
 			defer close(errs)
 			<-second // stays open past the first producer's nil message
 			send <- []byte("second-producer-message")
 		},
 	}
-	consumer := func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+	consumer := func(_ context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 		defer close(done)
 		defer close(errs)
 		for range recv {
@@ -205,16 +215,16 @@ func Test_NilMessage_DoesNotTruncateStream(t *testing.T) {
 // even fully successful ones, and every failed ExitOnError run leaked its
 // error-forwarding goroutines permanently (see
 // Test_LateErrorAfterExitOnError_NoPanic above for why that could also
-// panic). Runs that abandon a producer mid-send still park that producer's
-// own goroutine — the sdk contract has no cancellation hook for it — so
-// this measures well-behaved runs, where zero engine goroutines may remain.
+// panic). The erroring producer below finishes on its own every time (it
+// never blocks on ctx), so this specifically isolates the engine's own
+// bookkeeping from plugin cancellation behavior.
 func Test_GoroutinesDoNotAccumulateAcrossRuns(t *testing.T) {
 	pipeline := func() *Pipeline {
 		var got atomic.Int64
 		return &Pipeline{
 			Producers: []sdk.Producer{
 				emitN(50, []byte("x"), nil),
-				func(send chan<- []byte, errs chan<- error) {
+				func(_ context.Context, send chan<- []byte, errs chan<- error) {
 					defer close(send)
 					defer close(errs)
 					send <- []byte("y")
@@ -240,5 +250,47 @@ func Test_GoroutinesDoNotAccumulateAcrossRuns(t *testing.T) {
 	}
 	buf := make([]byte, 1<<16)
 	t.Fatalf("goroutines leaked across runs: %d -> %d\n%s",
+		baseline, runtime.NumGoroutine(), buf[:runtime.Stack(buf, true)])
+}
+
+// Capability test, not a regression: sdk v0.5.1 added ctx to Producer and
+// Consumer specifically so a plugin abandoned mid-send has a way to exit
+// instead of parking forever — the one leak PR #20's rewrite documented as
+// unavoidable ("the sdk contract has no context"). A producer that actually
+// selects on ctx.Done() alongside its send, cut off mid-stream by
+// StopAfter, must leave no goroutine behind at all.
+func Test_CtxAwareProducer_LeavesNoGoroutineOnAbandon(t *testing.T) {
+	blockForever := func(ctx context.Context, send chan<- []byte, errs chan<- error) {
+		defer close(send)
+		defer close(errs)
+		for {
+			select {
+			case send <- []byte("x"):
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+
+	baseline := runtime.NumGoroutine()
+	var got atomic.Int64
+	if err := panicSafeRun(t, &Pipeline{
+		Producers:   []sdk.Producer{blockForever},
+		Consumers:   []sdk.Consumer{countAll(&got)},
+		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		StopAfter:   3,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	buf := make([]byte, 1<<16)
+	t.Fatalf("ctx-aware producer still leaked a goroutine on abandon: %d -> %d\n%s",
 		baseline, runtime.NumGoroutine(), buf[:runtime.Stack(buf, true)])
 }

--- a/core/regression_test.go
+++ b/core/regression_test.go
@@ -266,6 +266,7 @@ func Test_CtxAwareProducer_LeavesNoGoroutineOnAbandon(t *testing.T) {
 		for {
 			select {
 			case send <- []byte("x"):
+				continue
 			case <-ctx.Done():
 				return
 			}

--- a/core/regression_test.go
+++ b/core/regression_test.go
@@ -1,0 +1,244 @@
+package core
+
+import (
+	"errors"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psyduck-etl/sdk"
+
+	"github.com/gastrodon/psyduck/stdlib/flow"
+)
+
+// This file holds regression tests for the concurrency bugs the pre-rewrite
+// engine had (join()/joinProducers/joinConsumers in core/build.go, the
+// four-goroutine RunPipeline in core/run.go — both deleted by the rewrite
+// that introduced this file). Each test below reproduces the exact scenario
+// that used to panic or deadlock that engine.
+//
+// That isn't a claim taken on faith: before writing these, the deleted
+// implementation (git show 5c9985f:core/{build,run}.go) was checked out
+// into an isolated module and run directly against these same scenarios.
+// Results:
+//
+//   - the #19/#11 scenario in Test_LateErrorAfterExitOnError_NoPanic
+//     deterministically panicked the old engine with "send on closed
+//     channel", inside the goroutine that forwards errorProducer into the
+//     aggregate errs channel (old run.go's RunPipeline.func1) — the
+//     forwarder blocks because RunPipeline already returned and stopped
+//     reading errs, then panics the instant the data-forwarding goroutine
+//     closes that same channel out from under it.
+//   - the #10 scenario in Test_ConsumerStopAfter_NoDeadlock hung the old
+//     engine indefinitely (confirmed blocked past a 3s bound): the
+//     stop-after wrapper stopped reading its recv channel without
+//     draining it, so RunPipeline's forward loop blocked forever on a send
+//     nobody would ever read again.
+//   - the #12 scenario in Test_NilMessage_DoesNotTruncateStream silently
+//     dropped every message after the nil — including ones from producers
+//     that hadn't even sent it — because old joinProducers used msg == nil
+//     on the joined channel as its "all producers closed" sentinel.
+//
+// #8 (produce-from seed closing without sending) is a parse-layer bug, not
+// a core-engine one; its regression test lives in
+// parse/hcl/hcl_test.go:TestParseProduceFromClosedSeed.
+
+// panicSafeRun runs RunPipeline in its own goroutine, converting any panic
+// into a clean test failure instead of crashing the whole test binary, and
+// fails if RunPipeline doesn't return within runTimeout (a hang is exactly
+// what these tests exist to catch).
+func panicSafeRun(t *testing.T, p *Pipeline) error {
+	t.Helper()
+	type outcome struct {
+		err   error
+		panic any
+		stack []byte
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				buf := make([]byte, 1<<16)
+				done <- outcome{panic: r, stack: buf[:runtime.Stack(buf, false)]}
+			}
+		}()
+		done <- outcome{err: RunPipeline(t.Context(), p)}
+	}()
+
+	select {
+	case o := <-done:
+		if o.panic != nil {
+			t.Fatalf("RunPipeline panicked: %v\n%s", o.panic, o.stack)
+		}
+		return o.err
+	case <-time.After(runTimeout):
+		t.Fatal("RunPipeline did not finish: pipeline deadlocked")
+		return nil
+	}
+}
+
+// Regression for #11 and #19: a producer that errors twice — once early
+// (triggering ExitOnError) and once late, well after RunPipeline has
+// already returned — must not crash the process. The old engine's
+// error-forwarding goroutine kept running after RunPipeline returned
+// (nothing ever stopped it), so the late error either parked that
+// goroutine forever (leak) or, if it arrived while the aggregate errs
+// channel was mid-close, panicked with "send on closed channel" — see the
+// file-level comment for the confirmed reproduction.
+func Test_LateErrorAfterExitOnError_NoPanic(t *testing.T) {
+	const lateDelay = 100 * time.Millisecond
+
+	producer := func(send chan<- []byte, errs chan<- error) {
+		defer close(send)
+		defer close(errs)
+		send <- []byte("x")
+		errs <- errors.New("err1")
+		time.Sleep(lateDelay)
+		errs <- errors.New("err2 (arrives after RunPipeline already returned)")
+	}
+	consumer := func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+		defer close(done)
+		defer close(errs)
+		for range recv {
+		}
+	}
+
+	start := time.Now()
+	err := panicSafeRun(t, &Pipeline{
+		Producers:   []sdk.Producer{producer},
+		Consumers:   []sdk.Consumer{consumer},
+		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		ExitOnError: true,
+	})
+	elapsed := time.Since(start)
+
+	if err == nil || !strings.Contains(err.Error(), "err1") {
+		t.Fatalf("want err1 to abort the run, got %v", err)
+	}
+	if elapsed >= lateDelay {
+		t.Fatalf("RunPipeline waited for the late error instead of returning on the first one: took %s", elapsed)
+	}
+
+	// err2 is sent lateDelay after err1; give it time to arrive at whatever
+	// (now-cancelled) forwarder would have received it, so a reintroduced
+	// panic happens inside this test's window instead of silently later.
+	time.Sleep(2 * lateDelay)
+	t.Log("survived the late error without panicking")
+}
+
+// Regression for #10: a consumer whose stop-after cutoff is smaller than
+// what the producer sends used to deadlock the pipeline permanently — the
+// stop-after wrapper broke out of its receive loop without draining the
+// rest, so whatever kept sending into it blocked forever on a send nobody
+// would ever read again.
+func Test_ConsumerStopAfter_NoDeadlock(t *testing.T) {
+	var got atomic.Int64
+	err := panicSafeRun(t, &Pipeline{
+		Producers:   []sdk.Producer{emitN(100, []byte("x"), nil)},
+		Consumers:   []sdk.Consumer{flow.Consumer(countAll(&got), 0, 0, 3)},
+		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := got.Load(); n != 3 {
+		t.Fatalf("want exactly 3 consumed, got %d", n)
+	}
+}
+
+// Regression for #12: with two or more producers, the old joinProducers
+// used msg == nil on its merged channel as the "all producers closed"
+// sentinel — indistinguishable from a producer legitimately sending a nil
+// []byte. That truncated the whole stream early, silently dropping every
+// later message from every producer, not just the one that sent the nil.
+// (A single producer bypassed the join entirely in the old code, so this
+// needs at least two to actually exercise the bug.)
+func Test_NilMessage_DoesNotTruncateStream(t *testing.T) {
+	var got atomic.Int64
+	second := make(chan struct{})
+	producers := []sdk.Producer{
+		func(send chan<- []byte, errs chan<- error) {
+			defer close(send)
+			defer close(errs)
+			send <- []byte("before")
+			send <- nil
+			send <- []byte("after")
+		},
+		func(send chan<- []byte, errs chan<- error) {
+			defer close(send)
+			defer close(errs)
+			<-second // stays open past the first producer's nil message
+			send <- []byte("second-producer-message")
+		},
+	}
+	consumer := func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+		defer close(done)
+		defer close(errs)
+		for range recv {
+			if got.Add(1) == 2 {
+				close(second) // let the second producer send once "after" arrived
+			}
+		}
+	}
+
+	err := panicSafeRun(t, &Pipeline{
+		Producers:   producers,
+		Consumers:   []sdk.Consumer{consumer},
+		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// producer 1 sends "before", a filtered-out nil, then "after"; "after"
+	// arriving is what unblocks producer 2 to send its own message. Seeing
+	// all 3 ("before", "after", "second-producer-message") proves the nil
+	// didn't truncate the stream for either producer.
+	if n := got.Load(); n != 3 {
+		t.Fatalf("stream truncated at the nil sentinel: got %d messages, want 3", n)
+	}
+}
+
+// Regression for #11/#19: a run the engine completes must release every
+// goroutine it started — the old join machinery leaked a fixed set per run,
+// even fully successful ones, and every failed ExitOnError run leaked its
+// error-forwarding goroutines permanently (see
+// Test_LateErrorAfterExitOnError_NoPanic above for why that could also
+// panic). Runs that abandon a producer mid-send still park that producer's
+// own goroutine — the sdk contract has no cancellation hook for it — so
+// this measures well-behaved runs, where zero engine goroutines may remain.
+func Test_GoroutinesDoNotAccumulateAcrossRuns(t *testing.T) {
+	pipeline := func() *Pipeline {
+		var got atomic.Int64
+		return &Pipeline{
+			Producers: []sdk.Producer{
+				emitN(50, []byte("x"), nil),
+				func(send chan<- []byte, errs chan<- error) {
+					defer close(send)
+					defer close(errs)
+					send <- []byte("y")
+					errs <- errors.New("mid-stream failure")
+				},
+			},
+			Consumers:   []sdk.Consumer{countAll(&got), countAll(&got)},
+			Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		}
+	}
+
+	baseline := runtime.NumGoroutine()
+	for i := 0; i < 25; i++ {
+		panicSafeRun(t, pipeline())
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline+2 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	buf := make([]byte, 1<<16)
+	t.Fatalf("goroutines leaked across runs: %d -> %d\n%s",
+		baseline, runtime.NumGoroutine(), buf[:runtime.Stack(buf, true)])
+}

--- a/core/run.go
+++ b/core/run.go
@@ -16,11 +16,13 @@ accepting (see sink). Errors from any side are logged; with ExitOnError set
 the first one also cancels the pipeline and is returned. Cancelling ctx
 stops the run promptly and returns ctx's error.
 
-Every goroutine the engine starts — its own and every plugin's — is
-released before RunPipeline returns: producers and consumers receive the
-pipeline's ctx and are contractually required to select on ctx.Done()
-alongside their sends, so an abandoned plugin is expected to exit on
-cancellation rather than parking on its last send.
+Every goroutine the engine starts is signaled to stop before RunPipeline
+returns, and the engine's own goroutines are joined. Plugin goroutines are
+signaled but not joined on the cancellation path: producers and consumers
+receive the pipeline's ctx and are contractually required to select on
+ctx.Done() alongside their sends, so a conforming plugin exits promptly on
+cancellation — but one that ignores ctx may still be winding down (or
+parked forever) after RunPipeline returns.
 */
 func RunPipeline(outer context.Context, pipeline *Pipeline) error {
 	ctx, cancel := context.WithCancel(outer)

--- a/core/run.go
+++ b/core/run.go
@@ -1,56 +1,91 @@
 package core
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"sync"
+)
 
-func RunPipeline(pipeline *Pipeline) error {
-	dataProducer, errorProducer := make(chan []byte), make(chan error)
-	dataConsumer, errorConsumer, finishConsumer := make(chan []byte), make(chan error), make(chan struct{})
-	errs := make(chan error)
+/*
+RunPipeline drives a built pipeline until its producers are exhausted, all
+of its consumers finish, StopAfter is reached, or ctx ends.
 
-	go pipeline.Producer(dataProducer, errorProducer)
-	go pipeline.Consumer(dataConsumer, errorConsumer, finishConsumer)
+Producers are merged into one iter.Seq2 stream (see produce); each message
+runs through the transformer stack and fans out to every consumer still
+accepting (see sink). Errors from any side are logged; with ExitOnError set
+the first one also cancels the pipeline and is returned. Cancelling ctx
+stops the run promptly and returns ctx's error.
 
-	go func() {
-		for err := range errorProducer {
-			if err != nil {
-				errs <- fmt.Errorf("producer supplied error: %s", err)
-			}
-		}
-	}()
+Every goroutine the engine starts is released before RunPipeline returns.
+Plugin goroutines themselves cannot be interrupted mid-send — the sdk
+contract has no context — so an abandoned producer may park permanently on
+its last send; that is bounded, one per plugin, and harmless.
+*/
+func RunPipeline(outer context.Context, pipeline *Pipeline) error {
+	ctx, cancel := context.WithCancel(outer)
+	defer cancel()
 
-	go func() {
-		for err := range errorConsumer {
-			if err != nil {
-				errs <- fmt.Errorf("consumer supplied error: %s", err)
-			}
-		}
-	}()
+	logger := pipeline.logger
+	if logger == nil {
+		logger = pipelineLogger()
+	}
 
-	go func() {
-		for msg := range dataProducer {
-			transformed, err := pipeline.Transformer(msg)
-			if err != nil {
-				errs <- fmt.Errorf("transformer supplied error: %s", err)
-			}
-
-			if transformed == nil {
-				continue
-			}
-
-			dataConsumer <- transformed
-		}
-
-		close(dataConsumer)
-		<-finishConsumer
-		close(errs)
-	}()
-
-	for err := range errs {
-		pipeline.logger.Error(err)
+	var failMu sync.Mutex
+	var failure error
+	report := func(err error) {
+		logger.Error(err)
 		if pipeline.ExitOnError {
-			return err
+			failMu.Lock()
+			if failure == nil {
+				failure = err
+				cancel()
+			}
+			failMu.Unlock()
 		}
 	}
 
-	return nil
+	transform := pipeline.Transformer
+	if transform == nil {
+		transform = func(msg []byte) ([]byte, error) { return msg, nil }
+	}
+
+	consumers := startSink(ctx, pipeline.Consumers, report)
+
+	delivered := 0
+	for msg, err := range produce(ctx, pipeline.Producers) {
+		if err != nil {
+			report(fmt.Errorf("producer supplied error: %w", err))
+			continue
+		}
+
+		transformed, err := transform(msg)
+		if err != nil {
+			report(fmt.Errorf("transformer supplied error: %w", err))
+			continue
+		}
+		if transformed == nil {
+			continue // filtered out
+		}
+
+		if !consumers.send(ctx, transformed) {
+			break // every consumer finished, or ctx ended
+		}
+
+		delivered++
+		if pipeline.StopAfter > 0 && delivered >= pipeline.StopAfter {
+			break
+		}
+	}
+
+	consumers.close()
+	consumers.flush(ctx)
+	cancel() // release error forwarders whose channels never close
+	consumers.waitErrs()
+
+	failMu.Lock()
+	defer failMu.Unlock()
+	if failure != nil {
+		return failure
+	}
+	return outer.Err() // non-nil only when the caller's ctx ended the run
 }

--- a/core/run.go
+++ b/core/run.go
@@ -16,10 +16,11 @@ accepting (see sink). Errors from any side are logged; with ExitOnError set
 the first one also cancels the pipeline and is returned. Cancelling ctx
 stops the run promptly and returns ctx's error.
 
-Every goroutine the engine starts is released before RunPipeline returns.
-Plugin goroutines themselves cannot be interrupted mid-send — the sdk
-contract has no context — so an abandoned producer may park permanently on
-its last send; that is bounded, one per plugin, and harmless.
+Every goroutine the engine starts — its own and every plugin's — is
+released before RunPipeline returns: producers and consumers receive the
+pipeline's ctx and are contractually required to select on ctx.Done()
+alongside their sends, so an abandoned plugin is expected to exit on
+cancellation rather than parking on its last send.
 */
 func RunPipeline(outer context.Context, pipeline *Pipeline) error {
 	ctx, cancel := context.WithCancel(outer)

--- a/core/run_test.go
+++ b/core/run_test.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/psyduck-etl/sdk"
-
-	"github.com/gastrodon/psyduck/stdlib/flow"
 )
 
 // runTimeout guards every RunPipeline call in this file: the old engine's
@@ -154,47 +151,6 @@ func Test_RunPipeline_filtering(t *testing.T) {
 	}
 }
 
-// Regression for #12: a producer legitimately sending a nil []byte must not
-// be mistaken for its channel closing — messages after the nil still flow.
-func Test_RunPipeline_nilMessage(t *testing.T) {
-	var got atomic.Int64
-	err := mustRun(t, t.Context(), &Pipeline{
-		Producers: []sdk.Producer{func(send chan<- []byte, errs chan<- error) {
-			defer close(send)
-			defer close(errs)
-			send <- []byte("before")
-			send <- nil
-			send <- []byte("after")
-		}},
-		Consumers:   []sdk.Consumer{countAll(&got)},
-		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	// nil transforms to nil and is filtered; the message after it survives
-	if n := got.Load(); n != 2 {
-		t.Fatalf("stream truncated at nil message: got %d of 2", n)
-	}
-}
-
-// Regression for #10: a consumer stop-after smaller than the produced count
-// used to deadlock the pipeline on a send nobody read.
-func Test_RunPipeline_consumerStopAfter(t *testing.T) {
-	var got atomic.Int64
-	err := mustRun(t, t.Context(), &Pipeline{
-		Producers:   []sdk.Producer{emitN(100, []byte("x"), nil)},
-		Consumers:   []sdk.Consumer{flow.Consumer(countAll(&got), 0, 0, 3)},
-		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n := got.Load(); n != 3 {
-		t.Fatalf("want exactly 3 consumed, got %d", n)
-	}
-}
-
 // Pipeline-level stop-after must terminate even an infinite producer.
 func Test_RunPipeline_stopAfter(t *testing.T) {
 	var got atomic.Int64
@@ -305,68 +261,4 @@ func Test_RunPipeline_errors(t *testing.T) {
 			t.Fatalf("want the consumer's error, got %v", err)
 		}
 	})
-}
-
-// Regression for #19's panic hazard: an error emitted after the data channel
-// closes must never crash the engine, whether or not it can still be
-// reported.
-func Test_RunPipeline_lateError(t *testing.T) {
-	late := func(send chan<- []byte, errs chan<- error) {
-		send <- []byte("x")
-		close(send)
-		errs <- errors.New("late cleanup failure")
-		close(errs)
-	}
-	var got atomic.Int64
-	if err := mustRun(t, t.Context(), &Pipeline{
-		Producers:   []sdk.Producer{late, emitN(5, []byte("y"), nil)},
-		Consumers:   []sdk.Consumer{countAll(&got)},
-		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if n := got.Load(); n != 6 {
-		t.Fatalf("want 6 messages, got %d", n)
-	}
-}
-
-// Regression for #11/#19: a run the engine completes must release every
-// goroutine it started — the old join machinery leaked a fixed set per run,
-// even fully successful ones. Runs that abandon a producer mid-send park
-// that producer's own goroutine (the sdk contract has no cancellation), so
-// this measures well-behaved runs, where zero engine goroutines may remain.
-func Test_RunPipeline_goroutineBounded(t *testing.T) {
-	pipeline := func() *Pipeline {
-		var got atomic.Int64
-		return &Pipeline{
-			Producers: []sdk.Producer{
-				emitN(50, []byte("x"), nil),
-				func(send chan<- []byte, errs chan<- error) {
-					defer close(send)
-					defer close(errs)
-					send <- []byte("y")
-					errs <- errors.New("mid-stream failure")
-				},
-			},
-			Consumers:   []sdk.Consumer{countAll(&got), countAll(&got)},
-			Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
-		}
-	}
-
-	baseline := runtime.NumGoroutine()
-	for i := 0; i < 25; i++ {
-		mustRun(t, t.Context(), pipeline())
-	}
-
-	// give parked goroutines a moment to unwind, then compare
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if runtime.NumGoroutine() <= baseline+2 {
-			return
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	buf := make([]byte, 1<<16)
-	t.Fatalf("goroutines leaked across runs: %d -> %d\n%s",
-		baseline, runtime.NumGoroutine(), buf[:runtime.Stack(buf, true)])
 }

--- a/core/run_test.go
+++ b/core/run_test.go
@@ -1,271 +1,372 @@
 package core
 
 import (
+	"context"
+	"errors"
 	"fmt"
-	"math"
+	"runtime"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/psyduck-etl/sdk"
-	"github.com/sirupsen/logrus"
+
+	"github.com/gastrodon/psyduck/stdlib/flow"
 )
 
-type Values func() (int, int)
+// runTimeout guards every RunPipeline call in this file: the old engine's
+// failure modes were deadlocks, so a hang IS the regression.
+const runTimeout = 10 * time.Second
 
-type testPipelineCase struct {
-	DataCount     int
-	Delay         bool
-	ProducerCount int
-	ConsumerCount int
-}
-
-func makeTestProducer(testcase testPipelineCase) (sdk.Producer, func() []int) {
-	counts := make([]int, testcase.ProducerCount)
-	producers := make([]sdk.Producer, testcase.ProducerCount)
-
-	for index := 0; index < testcase.ProducerCount; index++ {
-		producers[index] = func(slot int) sdk.Producer {
-			return func(send chan<- []byte, errs chan<- error) {
-				go func(slot int) {
-					for dataEach := 0; dataEach < testcase.DataCount; dataEach++ {
-						send <- []byte{byte(dataEach)}
-						counts[slot]++
-					}
-
-					close(send)
-					close(errs)
-				}(slot)
-			}
-
-		}(index)
-	}
-
-	return joinProducers(producers, pipelineLogger()), func() []int { return counts }
-}
-
-func makeTestConsumer(testcase testPipelineCase) (sdk.Consumer, func() []int) {
-	counts := make([]int, testcase.ConsumerCount)
-	consumers := make([]sdk.Consumer, testcase.ConsumerCount)
-
-	for index := 0; index < testcase.ConsumerCount; index++ {
-		consumers[index] = func(slot int) sdk.Consumer {
-			return func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
-				go func(i int) {
-					for range recv {
-						counts[i]++
-					}
-
-					close(done)
-				}(slot)
-			}
-
-		}(index)
-
-	}
-
-	return joinConsumers(consumers, pipelineLogger()), func() []int { return counts }
-}
-
-func testPipeline(testcase testPipelineCase) error {
-	producer, reportProducer := makeTestProducer(testcase)
-	consumer, reportConsumer := makeTestConsumer(testcase)
-	transformer := func(d []byte) ([]byte, error) { return d, nil }
-
-	if testcase.Delay {
-		transformer = func(d []byte) ([]byte, error) {
-			time.Sleep(50 * time.Millisecond)
-			return d, nil
-		}
-	}
-
-	pipeline := &Pipeline{
-		Producer:    producer,
-		Consumer:    consumer,
-		Transformer: transformer,
-	}
-
-	if err := RunPipeline(pipeline); err != nil {
+func mustRun(t *testing.T, ctx context.Context, p *Pipeline) error {
+	t.Helper()
+	got := make(chan error, 1)
+	go func() { got <- RunPipeline(ctx, p) }()
+	select {
+	case err := <-got:
 		return err
-	}
-
-	producerCount := reportProducer()
-	for index := range producerCount {
-		if producerCount[index] != testcase.DataCount {
-			return fmt.Errorf("produce count mismatch at %d! %d / %d", index, producerCount[index], testcase.DataCount)
-		}
-
-	}
-
-	consumerCount := reportConsumer()
-	for index := range consumerCount {
-		if consumerCount[index] != testcase.DataCount*testcase.ProducerCount {
-			return fmt.Errorf("consume count mismatch at %d! %d / %d * %d", index, consumerCount[index], testcase.DataCount, testcase.ProducerCount)
-		}
-	}
-
-	return nil
-}
-
-func Test_RunPipeline(test *testing.T) {
-	const (
-		COUNT_DELAY     = 100
-		COUNT_IMMEDIATE = 10_000
-		COUNT_BUFFERED  = 10_000
-	)
-
-	cases := []testPipelineCase{
-		{COUNT_DELAY, true, 1, 1},
-		{COUNT_DELAY, true, 10, 10},
-		{COUNT_IMMEDIATE, false, 1, 1},
-		{COUNT_IMMEDIATE, false, 1, 10},
-		{COUNT_IMMEDIATE, false, 10, 1},
-		{COUNT_IMMEDIATE, false, 10, 10},
-	}
-
-	for i, testcase := range cases {
-		if testcase.Delay && testing.Short() {
-			continue
-		}
-
-		if err := testPipeline(testcase); err != nil {
-			test.Fatalf("case %d failed: %s", i, err)
-		}
+	case <-time.After(runTimeout):
+		t.Fatal("RunPipeline did not finish: pipeline deadlocked")
+		return nil
 	}
 }
 
-func Test_RunPipeline_filtering(test *testing.T) {
-	received, limit, fac := byte(0), byte(100), byte(2)
-	testcase := &Pipeline{
-		Producer: func(send chan<- []byte, errs chan<- error) {
-			for i := byte(0); i < limit; i++ {
-				send <- []byte{i}
+// emitN produces count copies of payload, counting sends, closing both
+// channels on the way out like the stdlib producers do.
+func emitN(count int, payload []byte, sent *atomic.Int64) sdk.Producer {
+	return func(send chan<- []byte, errs chan<- error) {
+		defer close(send)
+		defer close(errs)
+		for i := 0; i < count; i++ {
+			send <- payload
+			if sent != nil {
+				sent.Add(1)
 			}
-			close(send)
-		},
-		Consumer: func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
-			for range recv {
-				received++
-			}
-
-			close(done)
-		},
-		Transformer: func(in []byte) ([]byte, error) {
-			if in[0]%fac != fac-1 {
-				return nil, nil
-
-			}
-			return in, nil
-		},
-	}
-
-	if err := RunPipeline(testcase); err != nil {
-		test.Fatal(err)
-	}
-
-	if received != limit/fac {
-		test.Fatalf("recieved %d != %d/%d!", received, limit, fac)
-	}
-}
-
-type testHook struct {
-	fn func()
-}
-
-func (testHook) Levels() []logrus.Level {
-	return []logrus.Level{logrus.ErrorLevel}
-}
-
-func (hook testHook) Fire(*logrus.Entry) error {
-	hook.fn()
-	return nil
-}
-
-func pipelineTestLogger(fn func()) *logrus.Logger {
-	log := pipelineLogger()
-	log.Hooks.Add(testHook{fn})
-	return log
-}
-
-func Test_RunPipeline_error(test *testing.T) {
-	errText := "error made"
-	produceErr := func(n int) sdk.Producer {
-		return func(send chan<- []byte, errs chan<- error) {
-			for i := 0; i < n; i++ {
-				send <- []byte{0}
-			}
-
-			errs <- fmt.Errorf("%s", errText)
 		}
 	}
+}
 
-	consumeErr := func(n int) sdk.Consumer {
-		return func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
-			for i := 0; i < n; i++ {
-				<-recv
-			}
-
-			errs <- fmt.Errorf("%s", errText)
+// emitForever produces payload until nothing receives anymore. It closes
+// neither channel — it never finishes on its own.
+func emitForever(payload []byte) sdk.Producer {
+	return func(send chan<- []byte, errs chan<- error) {
+		for {
+			send <- payload
 		}
 	}
+}
 
-	transformeErr := func(n int) sdk.Transformer {
-		i := 0
-		return func(in []byte) ([]byte, error) {
-			if i >= n {
-				return nil, fmt.Errorf("%s", errText)
-			}
-			i++
-			return in, nil
+// countAll consumes everything, counting receipts.
+func countAll(got *atomic.Int64) sdk.Consumer {
+	return func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+		defer close(done)
+		defer close(errs)
+		for range recv {
+			got.Add(1)
 		}
 	}
+}
 
-	testcases := [...]struct {
-		pipeline *Pipeline
-		want     error
+func Test_RunPipeline(t *testing.T) {
+	cases := []struct {
+		name                 string
+		count                int
+		producers, consumers int
+		delay                bool
 	}{
-		{&Pipeline{
-			Producer:    produceErr(50),
-			Consumer:    consumeErr(math.MaxInt32),
-			Transformer: transformeErr(math.MaxInt32),
-			ExitOnError: true,
-		}, fmt.Errorf("producer supplied error: %s", errText)},
-		{&Pipeline{
-			Producer:    produceErr(math.MaxInt32),
-			Consumer:    consumeErr(50),
-			Transformer: transformeErr(math.MaxInt32),
-			ExitOnError: true,
-		}, fmt.Errorf("consumer supplied error: %s", errText)},
-		{&Pipeline{
-			Producer:    produceErr(math.MaxInt32),
-			Consumer:    consumeErr(math.MaxInt32),
-			Transformer: transformeErr(50),
-			ExitOnError: true,
-		}, fmt.Errorf("transformer supplied error: %s", errText)},
-		{&Pipeline{
-			Producer:    joinProducers([]sdk.Producer{produceErr(50), produceErr(math.MaxInt32)}, logrus.StandardLogger()),
-			Consumer:    consumeErr(math.MaxInt32),
-			Transformer: transformeErr(math.MaxInt32),
-			ExitOnError: true,
-		}, fmt.Errorf("producer supplied error: %s", errText)},
-		{&Pipeline{
-			Producer:    produceErr(math.MaxInt32),
-			Consumer:    joinConsumers([]sdk.Consumer{consumeErr(math.MaxInt32), consumeErr(50)}, logrus.StandardLogger()),
-			Transformer: transformeErr(math.MaxInt32),
-			ExitOnError: true,
-		}, fmt.Errorf("consumer supplied error: %s", errText)},
+		{"1x1", 10_000, 1, 1, false},
+		{"1x10", 10_000, 1, 10, false},
+		{"10x1", 10_000, 10, 1, false},
+		{"10x10", 1_000, 10, 10, false},
+		{"slow transformer", 100, 10, 10, true},
 	}
 
-	for _, testcase := range testcases {
-		didFire := false
-		testcase.pipeline.logger = pipelineTestLogger(func() {
-			didFire = true
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sent := make([]atomic.Int64, tc.producers)
+			producers := make([]sdk.Producer, tc.producers)
+			for i := range producers {
+				producers[i] = emitN(tc.count, []byte{byte(i)}, &sent[i])
+			}
+
+			got := make([]atomic.Int64, tc.consumers)
+			consumers := make([]sdk.Consumer, tc.consumers)
+			for i := range consumers {
+				consumers[i] = countAll(&got[i])
+			}
+
+			transform := func(msg []byte) ([]byte, error) { return msg, nil }
+			if tc.delay {
+				transform = func(msg []byte) ([]byte, error) {
+					time.Sleep(time.Millisecond)
+					return msg, nil
+				}
+			}
+
+			err := mustRun(t, t.Context(), &Pipeline{
+				Producers:   producers,
+				Consumers:   consumers,
+				Transformer: transform,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for i := range sent {
+				if n := sent[i].Load(); n != int64(tc.count) {
+					t.Errorf("producer %d: sent %d of %d", i, n, tc.count)
+				}
+			}
+			want := int64(tc.count * tc.producers)
+			for i := range got {
+				if n := got[i].Load(); n != want {
+					t.Errorf("consumer %d: got %d of %d", i, n, want)
+				}
+			}
 		})
-		if err := RunPipeline(testcase.pipeline); err == nil {
-			test.Fatal("no error returned")
-		} else if err.Error() != testcase.want.Error() {
-			test.Fatalf("other error: %s != %s!", err, testcase.want)
-		} else if !didFire {
-			test.Fatal("logger hook did not fire")
+	}
+}
+
+func Test_RunPipeline_filtering(t *testing.T) {
+	var got atomic.Int64
+	err := mustRun(t, t.Context(), &Pipeline{
+		Producers: []sdk.Producer{func(send chan<- []byte, errs chan<- error) {
+			defer close(send)
+			defer close(errs)
+			for i := 0; i < 100; i++ {
+				send <- []byte{byte(i)}
+			}
+		}},
+		Consumers: []sdk.Consumer{countAll(&got)},
+		Transformer: func(msg []byte) ([]byte, error) {
+			if msg[0]%2 == 0 {
+				return nil, nil // filtered
+			}
+			return msg, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := got.Load(); n != 50 {
+		t.Fatalf("want 50 messages past the filter, got %d", n)
+	}
+}
+
+// Regression for #12: a producer legitimately sending a nil []byte must not
+// be mistaken for its channel closing — messages after the nil still flow.
+func Test_RunPipeline_nilMessage(t *testing.T) {
+	var got atomic.Int64
+	err := mustRun(t, t.Context(), &Pipeline{
+		Producers: []sdk.Producer{func(send chan<- []byte, errs chan<- error) {
+			defer close(send)
+			defer close(errs)
+			send <- []byte("before")
+			send <- nil
+			send <- []byte("after")
+		}},
+		Consumers:   []sdk.Consumer{countAll(&got)},
+		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// nil transforms to nil and is filtered; the message after it survives
+	if n := got.Load(); n != 2 {
+		t.Fatalf("stream truncated at nil message: got %d of 2", n)
+	}
+}
+
+// Regression for #10: a consumer stop-after smaller than the produced count
+// used to deadlock the pipeline on a send nobody read.
+func Test_RunPipeline_consumerStopAfter(t *testing.T) {
+	var got atomic.Int64
+	err := mustRun(t, t.Context(), &Pipeline{
+		Producers:   []sdk.Producer{emitN(100, []byte("x"), nil)},
+		Consumers:   []sdk.Consumer{flow.Consumer(countAll(&got), 0, 0, 3)},
+		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := got.Load(); n != 3 {
+		t.Fatalf("want exactly 3 consumed, got %d", n)
+	}
+}
+
+// Pipeline-level stop-after must terminate even an infinite producer.
+func Test_RunPipeline_stopAfter(t *testing.T) {
+	var got atomic.Int64
+	err := mustRun(t, t.Context(), &Pipeline{
+		Producers:   []sdk.Producer{emitForever([]byte("x"))},
+		Consumers:   []sdk.Consumer{countAll(&got)},
+		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		StopAfter:   5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := got.Load(); n != 5 {
+		t.Fatalf("want exactly 5 consumed, got %d", n)
+	}
+}
+
+// Cancelling the context stops a pipeline whose producer would never finish.
+func Test_RunPipeline_cancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	var got atomic.Int64
+	err := mustRun(t, ctx, &Pipeline{
+		Producers:   []sdk.Producer{emitForever([]byte("x"))},
+		Consumers:   []sdk.Consumer{countAll(&got)},
+		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+}
+
+func Test_RunPipeline_errors(t *testing.T) {
+	boom := errors.New("boom")
+	erroring := func(side string) sdk.Producer {
+		return func(send chan<- []byte, errs chan<- error) {
+			defer close(send)
+			defer close(errs)
+			send <- []byte("one")
+			errs <- fmt.Errorf("%s: %w", side, boom)
+			send <- []byte("two")
 		}
 	}
+
+	t.Run("producer error, exit-on-error", func(t *testing.T) {
+		var got atomic.Int64
+		err := mustRun(t, t.Context(), &Pipeline{
+			Producers:   []sdk.Producer{erroring("producer")},
+			Consumers:   []sdk.Consumer{countAll(&got)},
+			Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+			ExitOnError: true,
+		})
+		if !errors.Is(err, boom) {
+			t.Fatalf("want the producer's error, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "producer supplied error") {
+			t.Fatalf("unattributed error: %v", err)
+		}
+	})
+
+	t.Run("producer error, keep going", func(t *testing.T) {
+		var got atomic.Int64
+		err := mustRun(t, t.Context(), &Pipeline{
+			Producers:   []sdk.Producer{erroring("producer")},
+			Consumers:   []sdk.Consumer{countAll(&got)},
+			Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		})
+		if err != nil {
+			t.Fatalf("errors are logged, not returned, without exit-on-error: %v", err)
+		}
+		if n := got.Load(); n != 2 {
+			t.Fatalf("stream should survive the error: got %d of 2", n)
+		}
+	})
+
+	t.Run("transformer error, exit-on-error", func(t *testing.T) {
+		var got atomic.Int64
+		err := mustRun(t, t.Context(), &Pipeline{
+			Producers:   []sdk.Producer{emitN(10, []byte("x"), nil)},
+			Consumers:   []sdk.Consumer{countAll(&got)},
+			Transformer: func(msg []byte) ([]byte, error) { return nil, boom },
+			ExitOnError: true,
+		})
+		if !errors.Is(err, boom) || !strings.Contains(err.Error(), "transformer supplied error") {
+			t.Fatalf("want the transformer's error, got %v", err)
+		}
+	})
+
+	t.Run("consumer error, exit-on-error", func(t *testing.T) {
+		consume := func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+			defer close(done)
+			defer close(errs)
+			for range recv {
+				errs <- fmt.Errorf("consumer: %w", boom)
+			}
+		}
+		err := mustRun(t, t.Context(), &Pipeline{
+			Producers:   []sdk.Producer{emitN(10, []byte("x"), nil)},
+			Consumers:   []sdk.Consumer{consume},
+			Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+			ExitOnError: true,
+		})
+		if !errors.Is(err, boom) || !strings.Contains(err.Error(), "consumer supplied error") {
+			t.Fatalf("want the consumer's error, got %v", err)
+		}
+	})
+}
+
+// Regression for #19's panic hazard: an error emitted after the data channel
+// closes must never crash the engine, whether or not it can still be
+// reported.
+func Test_RunPipeline_lateError(t *testing.T) {
+	late := func(send chan<- []byte, errs chan<- error) {
+		send <- []byte("x")
+		close(send)
+		errs <- errors.New("late cleanup failure")
+		close(errs)
+	}
+	var got atomic.Int64
+	if err := mustRun(t, t.Context(), &Pipeline{
+		Producers:   []sdk.Producer{late, emitN(5, []byte("y"), nil)},
+		Consumers:   []sdk.Consumer{countAll(&got)},
+		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if n := got.Load(); n != 6 {
+		t.Fatalf("want 6 messages, got %d", n)
+	}
+}
+
+// Regression for #11/#19: a run the engine completes must release every
+// goroutine it started — the old join machinery leaked a fixed set per run,
+// even fully successful ones. Runs that abandon a producer mid-send park
+// that producer's own goroutine (the sdk contract has no cancellation), so
+// this measures well-behaved runs, where zero engine goroutines may remain.
+func Test_RunPipeline_goroutineBounded(t *testing.T) {
+	pipeline := func() *Pipeline {
+		var got atomic.Int64
+		return &Pipeline{
+			Producers: []sdk.Producer{
+				emitN(50, []byte("x"), nil),
+				func(send chan<- []byte, errs chan<- error) {
+					defer close(send)
+					defer close(errs)
+					send <- []byte("y")
+					errs <- errors.New("mid-stream failure")
+				},
+			},
+			Consumers:   []sdk.Consumer{countAll(&got), countAll(&got)},
+			Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		}
+	}
+
+	baseline := runtime.NumGoroutine()
+	for i := 0; i < 25; i++ {
+		mustRun(t, t.Context(), pipeline())
+	}
+
+	// give parked goroutines a moment to unwind, then compare
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline+2 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	buf := make([]byte, 1<<16)
+	t.Fatalf("goroutines leaked across runs: %d -> %d\n%s",
+		baseline, runtime.NumGoroutine(), buf[:runtime.Stack(buf, true)])
 }

--- a/core/run_test.go
+++ b/core/run_test.go
@@ -32,7 +32,7 @@ func mustRun(t *testing.T, ctx context.Context, p *Pipeline) error {
 // emitN produces count copies of payload, counting sends, closing both
 // channels on the way out like the stdlib producers do.
 func emitN(count int, payload []byte, sent *atomic.Int64) sdk.Producer {
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(_ context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 		for i := 0; i < count; i++ {
@@ -45,9 +45,12 @@ func emitN(count int, payload []byte, sent *atomic.Int64) sdk.Producer {
 }
 
 // emitForever produces payload until nothing receives anymore. It closes
-// neither channel — it never finishes on its own.
+// neither channel and deliberately ignores ctx — it never finishes on its
+// own, unlike a well-behaved plugin. Tests use it to prove RunPipeline
+// itself bounds StopAfter/cancellation rather than relying on plugin
+// cooperation with the sdk's context contract.
 func emitForever(payload []byte) sdk.Producer {
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(_ context.Context, send chan<- []byte, errs chan<- error) {
 		for {
 			send <- payload
 		}
@@ -56,7 +59,7 @@ func emitForever(payload []byte) sdk.Producer {
 
 // countAll consumes everything, counting receipts.
 func countAll(got *atomic.Int64) sdk.Consumer {
-	return func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+	return func(_ context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 		defer close(done)
 		defer close(errs)
 		for range recv {
@@ -128,7 +131,7 @@ func Test_RunPipeline(t *testing.T) {
 func Test_RunPipeline_filtering(t *testing.T) {
 	var got atomic.Int64
 	err := mustRun(t, t.Context(), &Pipeline{
-		Producers: []sdk.Producer{func(send chan<- []byte, errs chan<- error) {
+		Producers: []sdk.Producer{func(_ context.Context, send chan<- []byte, errs chan<- error) {
 			defer close(send)
 			defer close(errs)
 			for i := 0; i < 100; i++ {
@@ -190,7 +193,7 @@ func Test_RunPipeline_cancel(t *testing.T) {
 func Test_RunPipeline_errors(t *testing.T) {
 	boom := errors.New("boom")
 	erroring := func(side string) sdk.Producer {
-		return func(send chan<- []byte, errs chan<- error) {
+		return func(_ context.Context, send chan<- []byte, errs chan<- error) {
 			defer close(send)
 			defer close(errs)
 			send <- []byte("one")
@@ -244,7 +247,7 @@ func Test_RunPipeline_errors(t *testing.T) {
 	})
 
 	t.Run("consumer error, exit-on-error", func(t *testing.T) {
-		consume := func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+		consume := func(_ context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 			defer close(done)
 			defer close(errs)
 			for range recv {

--- a/core/sink.go
+++ b/core/sink.go
@@ -63,6 +63,12 @@ func startSink(ctx context.Context, consumers []sdk.Consumer, report func(error)
 // any consumer remains live — false means the pipeline has nowhere left to
 // deliver and should stop producing. A false return also covers ctx ending
 // mid-delivery.
+//
+// If a consumer closes done while it can still receive, select may pick
+// either case: one extra message can land in a consumer that has already
+// signaled done. Consumers that close done early should therefore keep
+// draining (or stop receiving entirely) — the next send will observe done
+// and mark them finished.
 func (s *sink) send(ctx context.Context, msg []byte) bool {
 	for i := range s.ins {
 		if s.finished[i] {
@@ -89,6 +95,11 @@ func (s *sink) close() {
 }
 
 // flush waits for every consumer to signal done, giving up when ctx ends.
+// Giving up is deliberate: done is the only completion signal a consumer
+// has, so waiting without a ctx escape would hang forever on a consumer
+// that ignores cancellation. The cost is that on the cancellation path
+// consumers are signaled but not joined — a conforming consumer may still
+// be flushing for a moment after RunPipeline returns.
 func (s *sink) flush(ctx context.Context) {
 	for i := range s.dones {
 		if s.finished[i] {

--- a/core/sink.go
+++ b/core/sink.go
@@ -1,0 +1,110 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/psyduck-etl/sdk"
+)
+
+// sink fans messages out to a set of running consumers and tracks which of
+// them are still accepting. A consumer signals completion by closing its
+// done channel — usually after the sink closes its input, but a consumer
+// may finish early on its own (a stop-after wrapper, for example), and the
+// sink simply stops sending to it rather than blocking the pipeline.
+type sink struct {
+	ins      []chan []byte
+	dones    []chan struct{}
+	finished []bool
+	live     int
+	errsWG   sync.WaitGroup
+}
+
+// startSink launches every consumer and an error forwarder for each.
+// Forwarders hand errors to report and exit when their channel closes or
+// ctx ends — consumers are not required to close their errs channel.
+func startSink(ctx context.Context, consumers []sdk.Consumer, report func(error)) *sink {
+	s := &sink{
+		ins:      make([]chan []byte, len(consumers)),
+		dones:    make([]chan struct{}, len(consumers)),
+		finished: make([]bool, len(consumers)),
+		live:     len(consumers),
+	}
+
+	for i, consume := range consumers {
+		in, errs, done := make(chan []byte), make(chan error), make(chan struct{})
+		s.ins[i], s.dones[i] = in, done
+		go consume(in, errs, done)
+
+		s.errsWG.Add(1)
+		go func() {
+			defer s.errsWG.Done()
+			for {
+				select {
+				case err, ok := <-errs:
+					if !ok {
+						return
+					}
+					if err != nil {
+						report(fmt.Errorf("consumer supplied error: %w", err))
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	return s
+}
+
+// send delivers msg to every consumer still accepting. It reports whether
+// any consumer remains live — false means the pipeline has nowhere left to
+// deliver and should stop producing. A false return also covers ctx ending
+// mid-delivery.
+func (s *sink) send(ctx context.Context, msg []byte) bool {
+	for i := range s.ins {
+		if s.finished[i] {
+			continue
+		}
+		select {
+		case s.ins[i] <- msg:
+		case <-s.dones[i]:
+			s.finished[i] = true
+			s.live--
+		case <-ctx.Done():
+			return false
+		}
+	}
+	return s.live > 0
+}
+
+// close ends the message stream: every consumer's input channel is closed,
+// which is its signal to flush and close done.
+func (s *sink) close() {
+	for _, in := range s.ins {
+		close(in)
+	}
+}
+
+// flush waits for every consumer to signal done, giving up when ctx ends.
+func (s *sink) flush(ctx context.Context) {
+	for i := range s.dones {
+		if s.finished[i] {
+			continue
+		}
+		select {
+		case <-s.dones[i]:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// waitErrs blocks until every error forwarder has exited. Call after
+// cancelling the pipeline context so forwarders whose errs channel never
+// closes are released.
+func (s *sink) waitErrs() {
+	s.errsWG.Wait()
+}

--- a/core/sink.go
+++ b/core/sink.go
@@ -76,6 +76,7 @@ func (s *sink) send(ctx context.Context, msg []byte) bool {
 		}
 		select {
 		case s.ins[i] <- msg:
+			continue
 		case <-s.dones[i]:
 			s.finished[i] = true
 			s.live--
@@ -107,6 +108,7 @@ func (s *sink) flush(ctx context.Context) {
 		}
 		select {
 		case <-s.dones[i]:
+			continue
 		case <-ctx.Done():
 			return
 		}

--- a/core/sink.go
+++ b/core/sink.go
@@ -35,7 +35,7 @@ func startSink(ctx context.Context, consumers []sdk.Consumer, report func(error)
 	for i, consume := range consumers {
 		in, errs, done := make(chan []byte), make(chan error), make(chan struct{})
 		s.ins[i], s.dones[i] = in, done
-		go consume(in, errs, done)
+		go consume(ctx, in, errs, done)
 
 		s.errsWG.Add(1)
 		go func() {

--- a/core/stream.go
+++ b/core/stream.go
@@ -29,20 +29,17 @@ func emit(ctx context.Context, out chan<- result, r result) bool {
 
 // produce merges producers into a single stream of (message, error) pairs.
 //
-// Each producer runs in its own goroutine against fresh channels, and two
-// forwarders bridge it into the merged stream: closing the data channel is
-// the producer's completion signal, while errors flow for as long as any
-// data path is live. Plugins are not required to close their errs channel,
-// so error forwarders don't wait on one — once all data channels close they
-// sweep pending errors and exit. The stream ends when every producer has
-// completed, when ctx ends, or when the caller breaks out of the loop — in
-// every case all forwarders are released, not orphaned.
-//
-// The one goroutine produce cannot reclaim is the producer's own: sdk
-// plugins take no context, so a producer abandoned mid-send parks on its
-// last write to a channel nothing reads. That is bounded (one goroutine
-// per producer), panic-free, and fixable only by adding context to the sdk
-// contract.
+// Each producer runs in its own goroutine against fresh channels and the
+// pipeline's ctx, so an abandoned producer is expected to notice
+// cancellation and exit — the sdk contract requires plugins to select on
+// ctx.Done() alongside their sends. Two forwarders bridge each producer into
+// the merged stream: closing the data channel is the producer's completion
+// signal, while errors flow for as long as any data path is live. Plugins
+// are not required to close their errs channel, so error forwarders don't
+// wait on one — once all data channels close they sweep pending errors and
+// exit. The stream ends when every producer has completed, when ctx ends,
+// or when the caller breaks out of the loop — in every case all forwarders
+// are released, not orphaned.
 func produce(ctx context.Context, producers []sdk.Producer) iter.Seq2[[]byte, error] {
 	return func(yield func([]byte, error) bool) {
 		ctx, cancel := context.WithCancel(ctx)
@@ -54,7 +51,7 @@ func produce(ctx context.Context, producers []sdk.Producer) iter.Seq2[[]byte, er
 
 		for _, p := range producers {
 			data, errs := make(chan []byte), make(chan error)
-			go p(data, errs)
+			go p(ctx, data, errs)
 
 			dataWG.Add(1)
 			go func() {

--- a/core/stream.go
+++ b/core/stream.go
@@ -34,24 +34,31 @@ func emit(ctx context.Context, out chan<- result, r result) bool {
 // cancellation and exit — the sdk contract requires plugins to select on
 // ctx.Done() alongside their sends. Two forwarders bridge each producer into
 // the merged stream: closing the data channel is the producer's completion
-// signal, while errors flow for as long as any data path is live. Plugins
-// are not required to close their errs channel, so error forwarders don't
-// wait on one — once all data channels close they sweep pending errors and
-// exit. The stream ends when every producer has completed, when ctx ends,
-// or when the caller breaks out of the loop — in every case all forwarders
-// are released, not orphaned.
+// signal, and errors keep flowing until the producer function itself
+// returns. Plugins are not required to close their errs channel, so the
+// error forwarder instead watches for the producer's return — once the
+// function has returned no sender can exist, so a final non-blocking drain
+// of errs is race-free and no error sent before returning is ever lost.
+// (Corollary: a producer should return promptly after closing its data
+// channel; the stream does not end until it does, or ctx does.) The stream
+// ends when every producer has completed, when ctx ends, or when the caller
+// breaks out of the loop — in every case all forwarders are released, not
+// orphaned.
 func produce(ctx context.Context, producers []sdk.Producer) iter.Seq2[[]byte, error] {
 	return func(yield func([]byte, error) bool) {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
 		merged := make(chan result)
-		dataDone := make(chan struct{}) // closed once every data channel has closed
 		var dataWG, errsWG sync.WaitGroup
 
 		for _, p := range producers {
 			data, errs := make(chan []byte), make(chan error)
-			go p(ctx, data, errs)
+			returned := make(chan struct{}) // closed when the producer function returns
+			go func() {
+				defer close(returned)
+				p(ctx, data, errs)
+			}()
 
 			dataWG.Add(1)
 			go func() {
@@ -71,11 +78,10 @@ func produce(ctx context.Context, producers []sdk.Producer) iter.Seq2[[]byte, er
 				}
 			}()
 
-			// Errors received before the producer completes are always
-			// delivered. Once dataDone fires the forwarder sweeps whatever
-			// is already pending and exits — an error a plugin emits after
-			// closing its data channel races that sweep, best-effort by
-			// necessity since plugins need not close errs at all.
+			// Errors keep flowing until the producer function returns.
+			// After `returned` fires no sender exists, so the final
+			// non-blocking drain cannot race a send — every error emitted
+			// before the producer returned is delivered.
 			errsWG.Add(1)
 			go func() {
 				defer errsWG.Done()
@@ -90,7 +96,7 @@ func produce(ctx context.Context, producers []sdk.Producer) iter.Seq2[[]byte, er
 						}
 					case <-ctx.Done():
 						return
-					case <-dataDone:
+					case <-returned:
 						for {
 							select {
 							case err, ok := <-errs:
@@ -110,9 +116,8 @@ func produce(ctx context.Context, producers []sdk.Producer) iter.Seq2[[]byte, er
 		}
 
 		go func() {
-			dataWG.Wait()   // every producer closed its data channel (or ctx ended)
-			close(dataDone) // error forwarders sweep and exit
-			errsWG.Wait()   // no sender left before merged closes
+			dataWG.Wait() // every producer closed its data channel (or ctx ended)
+			errsWG.Wait() // every producer returned (or ctx ended); no sender left
 			close(merged)
 		}()
 

--- a/core/stream.go
+++ b/core/stream.go
@@ -1,0 +1,128 @@
+package core
+
+import (
+	"context"
+	"iter"
+	"sync"
+
+	"github.com/psyduck-etl/sdk"
+)
+
+// result carries one producer emission — a message or an error — through
+// the fan-in channel behind produce. It is transport only; the engine
+// consumes the pairs through iter.Seq2.
+type result struct {
+	msg []byte
+	err error
+}
+
+// emit sends r into out unless ctx ends first. It reports whether the send
+// landed.
+func emit(ctx context.Context, out chan<- result, r result) bool {
+	select {
+	case out <- r:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// produce merges producers into a single stream of (message, error) pairs.
+//
+// Each producer runs in its own goroutine against fresh channels, and two
+// forwarders bridge it into the merged stream: closing the data channel is
+// the producer's completion signal, while errors flow for as long as any
+// data path is live. Plugins are not required to close their errs channel,
+// so error forwarders don't wait on one — once all data channels close they
+// sweep pending errors and exit. The stream ends when every producer has
+// completed, when ctx ends, or when the caller breaks out of the loop — in
+// every case all forwarders are released, not orphaned.
+//
+// The one goroutine produce cannot reclaim is the producer's own: sdk
+// plugins take no context, so a producer abandoned mid-send parks on its
+// last write to a channel nothing reads. That is bounded (one goroutine
+// per producer), panic-free, and fixable only by adding context to the sdk
+// contract.
+func produce(ctx context.Context, producers []sdk.Producer) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		merged := make(chan result)
+		dataDone := make(chan struct{}) // closed once every data channel has closed
+		var dataWG, errsWG sync.WaitGroup
+
+		for _, p := range producers {
+			data, errs := make(chan []byte), make(chan error)
+			go p(data, errs)
+
+			dataWG.Add(1)
+			go func() {
+				defer dataWG.Done()
+				for {
+					select {
+					case msg, ok := <-data:
+						if !ok {
+							return
+						}
+						if !emit(ctx, merged, result{msg: msg}) {
+							return
+						}
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+
+			// Errors received before the producer completes are always
+			// delivered. Once dataDone fires the forwarder sweeps whatever
+			// is already pending and exits — an error a plugin emits after
+			// closing its data channel races that sweep, best-effort by
+			// necessity since plugins need not close errs at all.
+			errsWG.Add(1)
+			go func() {
+				defer errsWG.Done()
+				for {
+					select {
+					case err, ok := <-errs:
+						if !ok {
+							return
+						}
+						if err != nil && !emit(ctx, merged, result{err: err}) {
+							return
+						}
+					case <-ctx.Done():
+						return
+					case <-dataDone:
+						for {
+							select {
+							case err, ok := <-errs:
+								if !ok {
+									return
+								}
+								if err != nil && !emit(ctx, merged, result{err: err}) {
+									return
+								}
+							default:
+								return
+							}
+						}
+					}
+				}
+			}()
+		}
+
+		go func() {
+			dataWG.Wait()   // every producer closed its data channel (or ctx ended)
+			close(dataDone) // error forwarders sweep and exit
+			errsWG.Wait()   // no sender left before merged closes
+			close(merged)
+		}()
+
+		for r := range merged {
+			if !yield(r.msg, r.err) {
+				return // defer cancel unwinds the forwarders
+			}
+		}
+	}
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -118,7 +118,7 @@ func runExample(t *testing.T, name string, fix fixture) {
 	}
 	entry := filepath.Join("examples", file)
 
-	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.FileLoader, plugins)
+	pipelines, err := hcl.NewParserHCL().Parse(t.Context(), entry, parse.FileLoader, plugins)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -131,7 +131,7 @@ func runExample(t *testing.T, name string, fix fixture) {
 		return
 	}
 
-	built, err := core.BuildPipeline(pipe, plugins)
+	built, err := core.BuildPipeline(t.Context(), pipe, plugins)
 	if err != nil {
 		t.Fatalf("build %q: %v", name, err)
 	}
@@ -140,7 +140,7 @@ func runExample(t *testing.T, name string, fix fixture) {
 		return
 	}
 
-	if err := core.RunPipeline(built); err != nil {
+	if err := core.RunPipeline(t.Context(), built); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 
@@ -169,16 +169,16 @@ pipeline "check" {
 	load := func(path string) (parse.Source, error) {
 		return parse.Source{Name: path, Content: []byte(src)}, nil
 	}
-	pipelines, err := hcl.NewParserHCL().Parse("assert.psy", load, plugins)
+	pipelines, err := hcl.NewParserHCL().Parse(t.Context(), "assert.psy", load, plugins)
 	if err != nil {
 		t.Fatal(err)
 	}
-	bp, err := core.BuildPipeline(pipelines["check"], plugins)
+	bp, err := core.BuildPipeline(t.Context(), pipelines["check"], plugins)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bp.ExitOnError = true
-	if err := core.RunPipeline(bp); err == nil {
+	if err := core.RunPipeline(t.Context(), bp); err == nil {
 		t.Error("expected a false assert to error the pipeline")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.13
 require (
 	github.com/hashicorp/hcl/v2 v2.20.1
 	github.com/itchyny/gojq v0.12.19
-	github.com/psyduck-etl/sdk v0.5.0
+	github.com/psyduck-etl/sdk v0.5.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.27.1

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/psyduck-etl/sdk v0.5.0 h1:b9v11by93ZTomevfP9GskUnBTF+KjQvhDfru4J+IgVM=
 github.com/psyduck-etl/sdk v0.5.0/go.mod h1:gwCEsqNNSfP2cWK9zVVirWwYCb/vtOeLXR0eaiJTz3g=
+github.com/psyduck-etl/sdk v0.5.1 h1:qu7ezb6PL5IxJTNIT9Q11EgBzVK7Ya31S4dUGM1Sqc4=
+github.com/psyduck-etl/sdk v0.5.1/go.mod h1:gwCEsqNNSfP2cWK9zVVirWwYCb/vtOeLXR0eaiJTz3g=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/main.go
+++ b/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/psyduck-etl/sdk"
 	"github.com/urfave/cli/v2"
@@ -95,7 +98,7 @@ func loadPipelines(ctx *cli.Context) (map[string]parse.Pipeline, []sdk.Plugin, e
 	}
 	loaded = append(loaded, stdlib.Plugin())
 
-	pipelines, err := hcl.NewParserHCL().Parse(entry, parse.FileLoader, loaded)
+	pipelines, err := hcl.NewParserHCL().Parse(ctx.Context, entry, parse.FileLoader, loaded)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -118,7 +121,7 @@ func run(ctx *cli.Context) error {
 
 	built := make([]*core.Pipeline, 0, len(pipelines))
 	for _, pipe := range pipelines {
-		b, err := core.BuildPipeline(pipe, loaded)
+		b, err := core.BuildPipeline(ctx.Context, pipe, loaded)
 		if err != nil {
 			return err
 		}
@@ -126,12 +129,12 @@ func run(ctx *cli.Context) error {
 	}
 
 	if len(built) == 1 {
-		return core.RunPipeline(built[0])
+		return core.RunPipeline(ctx.Context, built[0])
 	}
 
 	errs := make(chan error, len(built))
 	for _, b := range built {
-		go func(b *core.Pipeline) { errs <- core.RunPipeline(b) }(b)
+		go func(b *core.Pipeline) { errs <- core.RunPipeline(ctx.Context, b) }(b)
 	}
 
 	var failed error
@@ -277,7 +280,12 @@ func main() {
 		},
 	}
 
-	if err := app.Run(os.Args); err != nil {
+	// SIGINT/SIGTERM cancel the context every pipeline runs under, so
+	// Ctrl-C winds pipelines down instead of tearing the process apart.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := app.RunContext(ctx, os.Args); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/parse/hcl/hcl.go
+++ b/parse/hcl/hcl.go
@@ -4,6 +4,8 @@
 package hcl
 
 import (
+	"context"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/psyduck-etl/sdk"
@@ -149,8 +151,12 @@ func (h *ParserHCL) Plugins(entry string, load parse.Loader) ([]parse.Plugin, er
 
 // Parse resolves entry — and everything it transitively imports — against
 // the given plugins, and returns every pipeline{} declared directly in
-// entry.
-func (h *ParserHCL) Parse(entry string, load parse.Loader, plugins []sdk.Plugin) (map[string]parse.Pipeline, error) {
+// entry. Resolution is pure evaluation today, so ctx is only checked on
+// entry; produce-from seeds run later under the ctx their drain receives.
+func (h *ParserHCL) Parse(ctx context.Context, entry string, load parse.Loader, plugins []sdk.Plugin) (map[string]parse.Pipeline, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	index := indexResources(plugins)
 	result, err := resolveFile(parse.ResolveImportPath("", entry), load, index, map[string]bool{}, map[string]*fileResult{})
 	if err != nil {

--- a/parse/hcl/hcl_test.go
+++ b/parse/hcl/hcl_test.go
@@ -1,9 +1,12 @@
 package hcl
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/psyduck-etl/sdk"
 
@@ -74,7 +77,7 @@ func drainAll(t *testing.T, b parse.ResourceFunc) []parse.Resource {
 	t.Helper()
 	out := []parse.Resource{}
 	for {
-		chunk, err := b(4)
+		chunk, err := b(t.Context(), 4)
 		if err != nil {
 			t.Fatalf("drain: %s", err)
 		}
@@ -171,7 +174,7 @@ func TestParse(t *testing.T) {
 		exit-on-error = true
 	}
 	`)
-	result, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +236,7 @@ func TestParseAmbiguousResource(t *testing.T) {
 		consume = [trash.t]
 	}
 	`)
-	_, err := NewParserHCL().Parse(entry, load, plugins)
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, plugins)
 	if err == nil || !strings.Contains(err.Error(), "alpha.constant, beta.constant") {
 		t.Fatalf("want ambiguity error listing candidates, got: %v", err)
 	}
@@ -247,7 +250,7 @@ func TestParseAmbiguousResource(t *testing.T) {
 		consume = [alpha.trash.t]
 	}
 	`)
-	_, err = NewParserHCL().Parse(entry, load, plugins)
+	_, err = NewParserHCL().Parse(t.Context(), entry, load, plugins)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +268,7 @@ func TestParseDuplicates(t *testing.T) {
 		consume = [trash.t]
 	}
 	`)
-	_, err := NewParserHCL().Parse(entry, load, plugins)
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, plugins)
 	if err == nil || !strings.Contains(err.Error(), "duplicate resource") {
 		t.Fatalf("want duplicate resource error, got: %v", err)
 	}
@@ -282,7 +285,7 @@ func TestParseDuplicates(t *testing.T) {
 		consume = [trash.t]
 	}
 	`)
-	_, err = NewParserHCL().Parse(entry, load, plugins)
+	_, err = NewParserHCL().Parse(t.Context(), entry, load, plugins)
 	if err == nil || !strings.Contains(err.Error(), "duplicate pipeline") {
 		t.Fatalf("want duplicate pipeline error, got: %v", err)
 	}
@@ -300,7 +303,7 @@ func TestParseProducerExclusivity(t *testing.T) {
 		consume      = [trash.t]
 	}
 	`)
-	_, err := NewParserHCL().Parse(entry, load, plugins)
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, plugins)
 	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Fatalf("want exclusivity error, got: %v", err)
 	}
@@ -311,7 +314,7 @@ func TestParseProducerExclusivity(t *testing.T) {
 		consume = [trash.t]
 	}
 	`)
-	_, err = NewParserHCL().Parse(entry, load, plugins)
+	_, err = NewParserHCL().Parse(t.Context(), entry, load, plugins)
 	if err == nil || !strings.Contains(err.Error(), "produce or produce-from is required") {
 		t.Fatalf("want missing producer error, got: %v", err)
 	}
@@ -331,7 +334,7 @@ func TestParseImportWholeFile(t *testing.T) {
 		}
 		`,
 	}
-	pipelines, err := NewParserHCL().Parse("b.psy", fs.load, []sdk.Plugin{testPlugin("test")})
+	pipelines, err := NewParserHCL().Parse(t.Context(), "b.psy", fs.load, []sdk.Plugin{testPlugin("test")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -375,7 +378,7 @@ func TestParseImportReusesWholePipeline(t *testing.T) {
 		}
 		`,
 	}
-	pipelines, err := NewParserHCL().Parse("b.psy", fs.load, []sdk.Plugin{testPlugin("test")})
+	pipelines, err := NewParserHCL().Parse(t.Context(), "b.psy", fs.load, []sdk.Plugin{testPlugin("test")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -407,7 +410,7 @@ func TestParseImportPluginQualified(t *testing.T) {
 		}
 		`,
 	}
-	pipelines, err := NewParserHCL().Parse("b.psy", fs.load, plugins)
+	pipelines, err := NewParserHCL().Parse(t.Context(), "b.psy", fs.load, plugins)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -421,7 +424,7 @@ func TestParseImportCycle(t *testing.T) {
 		"a.psy": `import { b = "b.psy" }`,
 		"b.psy": `import { a = "a.psy" }`,
 	}
-	_, err := NewParserHCL().Parse("a.psy", fs.load, []sdk.Plugin{testPlugin("test")})
+	_, err := NewParserHCL().Parse(t.Context(), "a.psy", fs.load, []sdk.Plugin{testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), "cycle") {
 		t.Fatalf("want import cycle error, got: %v", err)
 	}
@@ -461,7 +464,7 @@ func TestParseImportDiamond(t *testing.T) {
 	// b.psy and c.psy both import d.psy; d.psy should resolve once (not
 	// error as a spurious duplicate or cycle), and be reachable through
 	// both paths.
-	pipelines, err := NewParserHCL().Parse("a.psy", fs.load, []sdk.Plugin{testPlugin("test")})
+	pipelines, err := NewParserHCL().Parse(t.Context(), "a.psy", fs.load, []sdk.Plugin{testPlugin("test")})
 	if err != nil {
 		t.Fatalf("diamond import should resolve cleanly, got: %v", err)
 	}
@@ -475,7 +478,7 @@ func TestParseDuplicateLocal(t *testing.T) {
 	locals { foo = "first" }
 	locals { foo = "second" }
 	`)
-	_, err := NewParserHCL().Parse(entry, load, nil)
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, nil)
 	if err == nil || !strings.Contains(err.Error(), `duplicate local "foo"`) {
 		t.Fatalf("want duplicate local error, got: %v", err)
 	}
@@ -497,7 +500,7 @@ func TestParseLocalsNotSharedAcrossImports(t *testing.T) {
 		}
 		`,
 	}
-	pipelines, err := NewParserHCL().Parse("b.psy", fs.load, []sdk.Plugin{testPlugin("test")})
+	pipelines, err := NewParserHCL().Parse(t.Context(), "b.psy", fs.load, []sdk.Plugin{testPlugin("test")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,7 +523,7 @@ func TestParseUnknownQualifiedPlugin(t *testing.T) {
 		consume = [trash.t]
 	}
 	`)
-	_, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), `unknown plugin "unknown"`) {
 		t.Fatalf("want unknown plugin error, got: %v", err)
 	}
@@ -536,7 +539,7 @@ func TestParseUnknownResourceRef(t *testing.T) {
 		consume = [trash.t]
 	}
 	`)
-	_, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), "Unknown variable") {
 		t.Fatalf("want unknown variable error, got: %v", err)
 	}
@@ -567,7 +570,7 @@ func TestParseReservedNamespaceCollision(t *testing.T) {
 		consume = [trash.t]
 	}
 	`)
-	_, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{valuePlugin, testPlugin("test")})
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{valuePlugin, testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), "collides with reserved namespace") {
 		t.Fatalf("want namespace collision error, got: %v", err)
 	}
@@ -583,7 +586,7 @@ func TestParseUnsetEnv(t *testing.T) {
 		consume = [trash.t]
 	}
 	`)
-	result, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -606,7 +609,7 @@ func TestParseUnsetEnv(t *testing.T) {
 		consume = [trash.t]
 	}
 	`)
-	_, err = NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
+	_, err = NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), "Unknown variable") {
 		t.Fatalf("want unknown variable error, got: %v", err)
 	}
@@ -622,7 +625,7 @@ func TestParseUnknownAttribute(t *testing.T) {
 		consume = [trash.t]
 	}
 	`)
-	_, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), "Unsupported argument") {
 		t.Fatalf("want unsupported argument error, got: %v", err)
 	}
@@ -638,7 +641,7 @@ func TestParseEagerConfigError(t *testing.T) {
 		consume = [trash.t]
 	}
 	`)
-	_, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test")})
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
 	if err == nil || !strings.Contains(err.Error(), "invalid value for value") {
 		t.Fatalf("want eager conversion error, got: %v", err)
 	}
@@ -668,7 +671,7 @@ func TestParseProduceFromEnv(t *testing.T) {
 		consume      = [trash.t]
 	}
 	`)
-	result, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test"), seed})
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test"), seed})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -710,7 +713,7 @@ func TestParseProduceFrom(t *testing.T) {
 		consume      = [trash.t]
 	}
 	`)
-	result, err := NewParserHCL().Parse(entry, load, []sdk.Plugin{testPlugin("test"), meta})
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test"), meta})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -736,5 +739,66 @@ func TestParseProduceFrom(t *testing.T) {
 	}
 	if opts.Value != "from-remote" {
 		t.Fatalf("bad remote value: %q", opts.Value)
+	}
+}
+
+// seedPlugin builds a produce-from seed plugin around the given producer.
+func seedPlugin(p sdk.Producer) sdk.Plugin {
+	return sdk.NewInProc("meta",
+		&sdk.Resource{
+			Name:            "seed",
+			Kinds:           sdk.PRODUCER,
+			ProvideProducer: func(sdk.Parser) (sdk.Producer, error) { return p, nil },
+		},
+	)
+}
+
+const seedEntry = `
+	produce "seed" "s" {}
+	consume "trash" "t" {}
+	pipeline "main" {
+		produce-from = produce.seed.s
+		consume      = [trash.t]
+	}
+	`
+
+// Regression for #8: a seed that closes without sending used to read as an
+// empty remote config, surfacing much later as "pipeline has no producers".
+func TestParseProduceFromClosedSeed(t *testing.T) {
+	seed := seedPlugin(func(send chan<- []byte, errs chan<- error) {
+		close(send)
+		close(errs)
+	})
+
+	entry, load := src(seedEntry)
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test"), seed})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = result["main"].Producers(t.Context(), 4)
+	if err == nil || !strings.Contains(err.Error(), "closed without sending") {
+		t.Fatalf("want closed-without-sending error, got %v", err)
+	}
+}
+
+// Draining a produce-from stream is bounded by the caller's ctx, not only
+// by the builtin timeout.
+func TestParseProduceFromCancel(t *testing.T) {
+	seed := seedPlugin(func(send chan<- []byte, errs chan<- error) {
+		select {} // never sends
+	})
+
+	entry, load := src(seedEntry)
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test"), seed})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	_, err = result["main"].Producers(ctx, 4)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want deadline error, got %v", err)
 	}
 }

--- a/parse/hcl/hcl_test.go
+++ b/parse/hcl/hcl_test.go
@@ -46,7 +46,7 @@ func testPlugin(name string) sdk.Plugin {
 				if err := p(opts); err != nil {
 					return nil, err
 				}
-				return func(send chan<- []byte, errs chan<- error) {
+				return func(_ context.Context, send chan<- []byte, errs chan<- error) {
 					send <- []byte(opts.Value)
 					close(send)
 				}, nil
@@ -56,7 +56,7 @@ func testPlugin(name string) sdk.Plugin {
 			Name:  "trash",
 			Kinds: sdk.CONSUMER,
 			ProvideConsumer: func(sdk.Parser) (sdk.Consumer, error) {
-				return func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+				return func(_ context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 					for range recv {
 					}
 					close(done)
@@ -558,7 +558,7 @@ func TestParseReservedNamespaceCollision(t *testing.T) {
 				if err := p(opts); err != nil {
 					return nil, err
 				}
-				return func(send chan<- []byte, errs chan<- error) { close(send) }, nil
+				return func(_ context.Context, send chan<- []byte, errs chan<- error) { close(send) }, nil
 			},
 		},
 	)
@@ -655,7 +655,7 @@ func TestParseProduceFromEnv(t *testing.T) {
 			Name:  "seed",
 			Kinds: sdk.PRODUCER,
 			ProvideProducer: func(sdk.Parser) (sdk.Producer, error) {
-				return func(send chan<- []byte, errs chan<- error) {
+				return func(_ context.Context, send chan<- []byte, errs chan<- error) {
 					send <- []byte(`produce "constant" "remote" { value = env.PSYDUCK_REMOTE_ONLY }`)
 					close(send)
 				}, nil
@@ -693,7 +693,7 @@ func TestParseProduceFrom(t *testing.T) {
 			Name:  "seed",
 			Kinds: sdk.PRODUCER,
 			ProvideProducer: func(sdk.Parser) (sdk.Producer, error) {
-				return func(send chan<- []byte, errs chan<- error) {
+				return func(_ context.Context, send chan<- []byte, errs chan<- error) {
 					send <- []byte(`
 					produce "constant" "remote" {
 						value = "from-remote"
@@ -765,7 +765,7 @@ const seedEntry = `
 // Regression for #8: a seed that closes without sending used to read as an
 // empty remote config, surfacing much later as "pipeline has no producers".
 func TestParseProduceFromClosedSeed(t *testing.T) {
-	seed := seedPlugin(func(send chan<- []byte, errs chan<- error) {
+	seed := seedPlugin(func(_ context.Context, send chan<- []byte, errs chan<- error) {
 		close(send)
 		close(errs)
 	})
@@ -783,10 +783,13 @@ func TestParseProduceFromClosedSeed(t *testing.T) {
 }
 
 // Draining a produce-from stream is bounded by the caller's ctx, not only
-// by the builtin timeout.
+// by the builtin timeout. The seed honors ctx like a well-behaved plugin
+// should — it's drainSeed's own ctx.Done() handling under test here, not
+// resilience against a non-cooperating plugin (that's core's job, see
+// core/regression_test.go).
 func TestParseProduceFromCancel(t *testing.T) {
-	seed := seedPlugin(func(send chan<- []byte, errs chan<- error) {
-		select {} // never sends
+	seed := seedPlugin(func(ctx context.Context, send chan<- []byte, errs chan<- error) {
+		<-ctx.Done() // never sends
 	})
 
 	entry, load := src(seedEntry)

--- a/parse/hcl/resource.go
+++ b/parse/hcl/resource.go
@@ -1,6 +1,7 @@
 package hcl
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -265,6 +266,8 @@ func makePipeline(
 // Dynamic producers (produce-from)
 // ---------------------------------------------------------------------------
 
+// remoteTimeout bounds drainSeed when the caller's context carries no
+// deadline of its own; a caller-supplied deadline always wins.
 const remoteTimeout = 10 * time.Second
 
 // remoteBindings hides a dynamic producer behind the ordinary Bindings
@@ -276,21 +279,22 @@ const remoteTimeout = 10 * time.Second
 // collectProducer behavior. A future revision can keep draining messages.
 func remoteBindings(seed parse.Resource, ix *resourceIndex, localsCtx *hcl.EvalContext) parse.ResourceFunc {
 	var yield parse.ResourceFunc
-	return func(max int) ([]parse.Resource, error) {
+	return func(ctx context.Context, max int) ([]parse.Resource, error) {
 		if yield == nil {
-			bindings, err := drainSeed(seed, ix, localsCtx)
+			bindings, err := drainSeed(ctx, seed, ix, localsCtx)
 			if err != nil {
 				return nil, err
 			}
 			yield = parse.LiteralResourceFunc(bindings...)
 		}
-		return yield(max)
+		return yield(ctx, max)
 	}
 }
 
 // drainSeed binds and runs the seed producer, takes its first message, and
-// parses it as HCL produce blocks. Guarded by remoteTimeout.
-func drainSeed(seed parse.Resource, ix *resourceIndex, localsCtx *hcl.EvalContext) ([]parse.Resource, error) {
+// parses it as HCL produce blocks. Bounded by ctx's deadline, falling back
+// to remoteTimeout when ctx has none.
+func drainSeed(ctx context.Context, seed parse.Resource, ix *resourceIndex, localsCtx *hcl.EvalContext) ([]parse.Resource, error) {
 	plugin, ok := ix.plugins[seed.PluginID]
 	if !ok {
 		return nil, fmt.Errorf("produce-from %s: plugin %q not loaded", seed.Ref, seed.PluginID)
@@ -302,19 +306,33 @@ func drainSeed(seed parse.Resource, ix *resourceIndex, localsCtx *hcl.EvalContex
 	}
 	defer instance.Close()
 
+	if _, has := ctx.Deadline(); !has {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, remoteTimeout)
+		defer cancel()
+	}
+
 	send, errs := make(chan []byte), make(chan error)
 	go instance.Produce(send, errs)
 
-	timeout := time.NewTimer(remoteTimeout)
-	defer timeout.Stop()
-
-	select {
-	case <-timeout.C:
-		return nil, fmt.Errorf("produce-from %s: timeout waiting for remote producer", seed.Ref)
-	case err := <-errs:
-		return nil, fmt.Errorf("produce-from %s: remote producer error: %w", seed.Ref, err)
-	case msg := <-send:
-		return parseRemoteProducers(seed.Ref, msg, ix, localsCtx)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("produce-from %s: waiting for remote producer: %w", seed.Ref, ctx.Err())
+		case err, ok := <-errs:
+			if !ok {
+				errs = nil // closed; stop selecting on it
+				continue
+			}
+			if err != nil {
+				return nil, fmt.Errorf("produce-from %s: remote producer error: %w", seed.Ref, err)
+			}
+		case msg, ok := <-send:
+			if !ok {
+				return nil, fmt.Errorf("produce-from %s: seed producer closed without sending", seed.Ref)
+			}
+			return parseRemoteProducers(seed.Ref, msg, ix, localsCtx)
+		}
 	}
 }
 

--- a/parse/hcl/resource.go
+++ b/parse/hcl/resource.go
@@ -313,7 +313,7 @@ func drainSeed(ctx context.Context, seed parse.Resource, ix *resourceIndex, loca
 	}
 
 	send, errs := make(chan []byte), make(chan error)
-	go instance.Produce(send, errs)
+	go instance.Produce(ctx, send, errs)
 
 	for {
 		select {

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -1,6 +1,10 @@
 package parse
 
-import "github.com/psyduck-etl/sdk"
+import (
+	"context"
+
+	"github.com/psyduck-etl/sdk"
+)
 
 // Plugin identifies a plugin declared in configuration, before it has
 // been fetched or loaded.
@@ -38,5 +42,9 @@ type Parser interface {
 	// own; they're data for entry's pipelines to reuse). All
 	// parser-specific state (eval contexts, AST nodes) stays behind the
 	// Pipelines and the sdk.ConfigBlocks inside them.
-	Parse(entry string, load Loader, plugins []sdk.Plugin) (map[string]Pipeline, error)
+	//
+	// ctx bounds parse-time work only. Deferred work carried by the
+	// returned Pipelines (a produce-from seed runs when its ResourceFunc
+	// is drained) is bounded by the ctx handed to that drain instead.
+	Parse(ctx context.Context, entry string, load Loader, plugins []sdk.Plugin) (map[string]Pipeline, error)
 }

--- a/parse/pipeline.go
+++ b/parse/pipeline.go
@@ -1,6 +1,10 @@
 package parse
 
-import "github.com/psyduck-etl/sdk"
+import (
+	"context"
+
+	"github.com/psyduck-etl/sdk"
+)
 
 // Resource is a fully-parsed, not-yet-instantiated pipeline resource. It
 // carries no callable plugin code — just enough to find the owning plugin
@@ -16,15 +20,17 @@ type Resource struct {
 	Meta     sdk.BlockMeta          // pre-decoded host-owned attributes
 }
 
-// ResourceFunc yields ResourceFunc in chunks of up to max until exhausted.
-// A nil slice with nil error signals exhaustion.
-type ResourceFunc func(max int) ([]Resource, error)
+// ResourceFunc yields Resources in chunks of up to max until exhausted.
+// A nil slice with nil error signals exhaustion. Draining may do real work
+// (produce-from binds and runs its seed producer), so it takes the caller's
+// context and must respect its cancellation and deadline.
+type ResourceFunc func(ctx context.Context, max int) ([]Resource, error)
 
 // LiteralResourceFunc wraps a fixed slice into a ResourceFunc that yields it in
 // chunks and then exhausts.
 func LiteralResourceFunc(resources ...Resource) ResourceFunc {
 	pos := 0
-	return func(max int) ([]Resource, error) {
+	return func(_ context.Context, max int) ([]Resource, error) {
 		if max < 1 || pos >= len(resources) {
 			return nil, nil
 		}

--- a/parse/pipeline_test.go
+++ b/parse/pipeline_test.go
@@ -12,7 +12,7 @@ func TestLiteralResourceFunc(t *testing.T) {
 	sizes := []int{}
 	total := []Resource{}
 	for {
-		chunk, err := f(2)
+		chunk, err := f(t.Context(), 2)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -33,18 +33,18 @@ func TestLiteralResourceFunc(t *testing.T) {
 	}
 
 	// exhausted stream stays exhausted
-	if chunk, err := f(2); err != nil || chunk != nil {
+	if chunk, err := f(t.Context(), 2); err != nil || chunk != nil {
 		t.Fatalf("want exhausted, got %v %v", chunk, err)
 	}
 
 	// max < 1 yields nothing
 	f = LiteralResourceFunc(rs...)
-	if chunk, err := f(0); err != nil || chunk != nil {
+	if chunk, err := f(t.Context(), 0); err != nil || chunk != nil {
 		t.Fatalf("max=0: want nil, got %v %v", chunk, err)
 	}
 
 	// empty literal exhausts immediately
-	if chunk, err := LiteralResourceFunc()(4); err != nil || chunk != nil {
+	if chunk, err := LiteralResourceFunc()(t.Context(), 4); err != nil || chunk != nil {
 		t.Fatalf("empty: want nil, got %v %v", chunk, err)
 	}
 }

--- a/plugins/fetch.go
+++ b/plugins/fetch.go
@@ -52,9 +52,16 @@ func (f *fetcher) cleanup() {
 // build compiles codePath into a temporary .so. It never writes directly
 // into the store — the store only knows binaries by content hash, which
 // isn't known until after the build produces bytes to hash.
+//
+// plugin.Open refuses a .so whose race setting differs from the host's, so
+// the build mirrors this binary's own (mostly relevant to `go test -race`).
 func (f *fetcher) build(codePath string, spec parse.Plugin) (string, error) {
 	tmpOut := filepath.Join(f.tmpDir, spec.Name+".so")
-	cmd := exec.Command("go", "build", "-C", codePath, "-o", tmpOut, "-buildmode", "plugin")
+	args := []string{"build", "-C", codePath, "-o", tmpOut, "-buildmode", "plugin"}
+	if raceEnabled {
+		args = append(args, "-race")
+	}
+	cmd := exec.Command("go", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("failed to build %s: %w\noutput: %s", codePath, err, out)
 	}

--- a/plugins/fetch.go
+++ b/plugins/fetch.go
@@ -61,8 +61,7 @@ func (f *fetcher) build(codePath string, spec parse.Plugin) (string, error) {
 	if raceEnabled {
 		args = append(args, "-race")
 	}
-	cmd := exec.Command("go", args...)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := exec.Command("go", args...).CombinedOutput(); err != nil {
 		return "", fmt.Errorf("failed to build %s: %w\noutput: %s", codePath, err, out)
 	}
 	return tmpOut, nil

--- a/plugins/load_test.go
+++ b/plugins/load_test.go
@@ -82,7 +82,7 @@ func TestLoad_Integration(t *testing.T) {
 
 	send := make(chan []byte, 4)
 	errs := make(chan error, 1)
-	go inst.Produce(send, errs)
+	go inst.Produce(t.Context(), send, errs)
 
 	var got [][]byte
 	timeout := time.After(2 * time.Second)

--- a/plugins/race_off.go
+++ b/plugins/race_off.go
@@ -1,0 +1,8 @@
+//go:build !race
+
+package plugins
+
+// raceEnabled reports whether this binary was built with the race detector.
+// A plugin can only be loaded by a host built with the same race setting,
+// so fetcher.build must mirror it.
+const raceEnabled = false

--- a/plugins/race_on.go
+++ b/plugins/race_on.go
@@ -1,0 +1,8 @@
+//go:build race
+
+package plugins
+
+// raceEnabled reports whether this binary was built with the race detector.
+// A plugin can only be loaded by a host built with the same race setting,
+// so fetcher.build must mirror it.
+const raceEnabled = true

--- a/stdlib/consume/file.go
+++ b/stdlib/consume/file.go
@@ -1,12 +1,29 @@
 package consume
 
 import (
+	"context"
 	"fmt"
+	"io"
 
 	"github.com/psyduck-etl/sdk"
 
 	"github.com/gastrodon/psyduck/stdlib/transport"
 )
+
+// closeOnDone closes c the moment ctx ends, unless the returned stop fires
+// first. It exists to unblock a synchronous, otherwise uncancellable Write()
+// on a writer/connection when the consumer's ctx is cancelled.
+func closeOnDone(ctx context.Context, c io.Closer) (stop func()) {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			c.Close()
+		case <-done:
+		}
+	}()
+	return func() { close(done) }
+}
 
 type fileConfig struct {
 	Location     string  `psy:"location"`
@@ -42,7 +59,7 @@ func File(parse sdk.Parser) (sdk.Consumer, error) {
 		return nil, err
 	}
 
-	return func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+	return func(ctx context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 		defer close(done)
 		defer close(errs)
 
@@ -53,13 +70,19 @@ func File(parse sdk.Parser) (sdk.Consumer, error) {
 		}
 		defer wc.Close()
 
+		stop := closeOnDone(ctx, wc)
+		defer stop()
+
 		joiner := d.Joiner(wc)
 		for msg := range recv {
 			if err := joiner.Write(msg); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
 				errs <- err
 			}
 		}
-		if err := joiner.Close(); err != nil {
+		if err := joiner.Close(); err != nil && ctx.Err() == nil {
 			errs <- err
 		}
 	}, nil

--- a/stdlib/consume/request.go
+++ b/stdlib/consume/request.go
@@ -1,6 +1,7 @@
 package consume
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/psyduck-etl/sdk"
@@ -28,13 +29,13 @@ func Request(parse sdk.Parser) (sdk.Consumer, error) {
 		h.Method = "POST"
 	}
 
-	return func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+	return func(ctx context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 		defer close(done)
 		defer close(errs)
 
 		client := h.Client()
 		for msg := range recv {
-			if _, err := h.Do(client, msg); err != nil {
+			if _, err := h.Do(ctx, client, msg); err != nil && ctx.Err() == nil {
 				errs <- err
 			}
 		}

--- a/stdlib/consume/socket.go
+++ b/stdlib/consume/socket.go
@@ -1,6 +1,8 @@
 package consume
 
 import (
+	"context"
+
 	"github.com/psyduck-etl/sdk"
 
 	"github.com/gastrodon/psyduck/stdlib/transport"
@@ -34,7 +36,7 @@ func Socket(parse sdk.Parser) (sdk.Consumer, error) {
 		return nil, err
 	}
 
-	return func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+	return func(ctx context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 		defer close(done)
 		defer close(errs)
 
@@ -45,13 +47,19 @@ func Socket(parse sdk.Parser) (sdk.Consumer, error) {
 		}
 		defer wc.Close()
 
+		stop := closeOnDone(ctx, wc)
+		defer stop()
+
 		joiner := d.Joiner(wc)
 		for msg := range recv {
 			if err := joiner.Write(msg); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
 				errs <- err
 			}
 		}
-		if err := joiner.Close(); err != nil {
+		if err := joiner.Close(); err != nil && ctx.Err() == nil {
 			errs <- err
 		}
 	}, nil

--- a/stdlib/consume/trash.go
+++ b/stdlib/consume/trash.go
@@ -1,11 +1,13 @@
 package consume
 
 import (
+	"context"
+
 	"github.com/psyduck-etl/sdk"
 )
 
 func Trash(sdk.Parser) (sdk.Consumer, error) {
-	return func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+	return func(_ context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 		defer close(done)
 		defer close(errs)
 

--- a/stdlib/flow/flow.go
+++ b/stdlib/flow/flow.go
@@ -7,6 +7,7 @@
 package flow
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -40,54 +41,82 @@ func Limiter(perMinute, perSecond int) func() {
 }
 
 // Producer wraps p with rate limiting and a stop-after cutoff. With all limits
-// unset it returns p unchanged.
+// unset it returns p unchanged. p receives the same ctx as the wrapper — the
+// sdk contract requires it to select on ctx.Done() on its own — and the
+// wrapper's own relay to send also honors ctx, so an abandoned wrapped
+// producer never blocks past cancellation.
 func Producer(p sdk.Producer, perMinute, perSecond, stopAfter int) sdk.Producer {
 	if perMinute <= 0 && perSecond <= 0 && stopAfter <= 0 {
 		return p
 	}
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
+		defer close(send)
 		inner := make(chan []byte)
-		go p(inner, errs)
+		go p(ctx, inner, errs)
 
 		wait, count := Limiter(perMinute, perSecond), 0
-		for msg := range inner {
-			wait()
-			send <- msg
-			count++
-			if stopAfter > 0 && count >= stopAfter {
-				break
+		for {
+			select {
+			case msg, ok := <-inner:
+				if !ok {
+					return
+				}
+				wait()
+				select {
+				case send <- msg:
+				case <-ctx.Done():
+					return
+				}
+				count++
+				if stopAfter > 0 && count >= stopAfter {
+					return
+				}
+			case <-ctx.Done():
+				return
 			}
 		}
-		close(send)
 	}
 }
 
 // Consumer wraps c with rate limiting and a stop-after cutoff. With all limits
-// unset it returns c unchanged.
+// unset it returns c unchanged. c receives the same ctx as the wrapper, and
+// the wrapper's own relay from recv also honors ctx.
 //
-// At the cutoff the wrapper stops receiving and closes the inner stream; c
-// flushes and closes done. The wrapper deliberately does not drain recv —
-// done is the host's signal to stop sending (core's sink honors it), and
-// silently discarding messages would hide the cutoff from the host and keep
-// upstream producing into the void.
+// At the cutoff (or on cancellation) the wrapper stops receiving and closes
+// the inner stream; c flushes and closes done. The wrapper deliberately does
+// not drain recv — done is the host's signal to stop sending (core's sink
+// honors it), and silently discarding messages would hide the cutoff from
+// the host and keep upstream producing into the void.
 func Consumer(c sdk.Consumer, perMinute, perSecond, stopAfter int) sdk.Consumer {
 	if perMinute <= 0 && perSecond <= 0 && stopAfter <= 0 {
 		return c
 	}
-	return func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+	return func(ctx context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 		inner := make(chan []byte)
-		go c(inner, errs, done)
+		go c(ctx, inner, errs, done)
+		defer close(inner)
 
 		wait, count := Limiter(perMinute, perSecond), 0
-		for msg := range recv {
-			wait()
-			inner <- msg
-			count++
-			if stopAfter > 0 && count >= stopAfter {
-				break
+		for {
+			select {
+			case msg, ok := <-recv:
+				if !ok {
+					return
+				}
+				wait()
+				select {
+				case inner <- msg:
+				case <-ctx.Done():
+					return
+				}
+				count++
+				if stopAfter > 0 && count >= stopAfter {
+					return
+				}
+			case <-ctx.Done():
+				return
 			}
 		}
-		close(inner)
 	}
 }
 

--- a/stdlib/flow/flow.go
+++ b/stdlib/flow/flow.go
@@ -64,6 +64,12 @@ func Producer(p sdk.Producer, perMinute, perSecond, stopAfter int) sdk.Producer 
 
 // Consumer wraps c with rate limiting and a stop-after cutoff. With all limits
 // unset it returns c unchanged.
+//
+// At the cutoff the wrapper stops receiving and closes the inner stream; c
+// flushes and closes done. The wrapper deliberately does not drain recv —
+// done is the host's signal to stop sending (core's sink honors it), and
+// silently discarding messages would hide the cutoff from the host and keep
+// upstream producing into the void.
 func Consumer(c sdk.Consumer, perMinute, perSecond, stopAfter int) sdk.Consumer {
 	if perMinute <= 0 && perSecond <= 0 && stopAfter <= 0 {
 		return c

--- a/stdlib/flow/flow_test.go
+++ b/stdlib/flow/flow_test.go
@@ -1,6 +1,7 @@
 package flow
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -31,7 +32,7 @@ func TestLimiter(t *testing.T) {
 
 func TestProducer(t *testing.T) {
 	emit := func(n int) sdk.Producer {
-		return func(send chan<- []byte, errs chan<- error) {
+		return func(_ context.Context, send chan<- []byte, errs chan<- error) {
 			for i := 0; i < n; i++ {
 				send <- []byte{byte(i)}
 			}
@@ -40,7 +41,7 @@ func TestProducer(t *testing.T) {
 	}
 	recvAll := func(p sdk.Producer) [][]byte {
 		send, errs := make(chan []byte), make(chan error)
-		go p(send, errs)
+		go p(t.Context(), send, errs)
 		got := [][]byte{}
 		for msg := range send {
 			got = append(got, msg)
@@ -80,7 +81,7 @@ func TestProducer(t *testing.T) {
 func TestConsumer(t *testing.T) {
 	run := func(perMinute, stopAfter, feed int) int {
 		count := 0
-		consume := func(recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+		consume := func(_ context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
 			for range recv {
 				count++
 			}
@@ -88,7 +89,7 @@ func TestConsumer(t *testing.T) {
 		}
 
 		recv, errs, done := make(chan []byte), make(chan error), make(chan struct{})
-		go Consumer(consume, perMinute, 0, stopAfter)(recv, errs, done)
+		go Consumer(consume, perMinute, 0, stopAfter)(t.Context(), recv, errs, done)
 
 		stop := make(chan struct{})
 		go func() {

--- a/stdlib/flow/flow_test.go
+++ b/stdlib/flow/flow_test.go
@@ -97,6 +97,7 @@ func TestConsumer(t *testing.T) {
 			for i := 0; i < feed; i++ {
 				select {
 				case recv <- []byte{byte(i)}:
+					continue
 				case <-stop:
 					return
 				}

--- a/stdlib/integration/broadcast_test.go
+++ b/stdlib/integration/broadcast_test.go
@@ -39,7 +39,7 @@ func TestFileBroadcast(t *testing.T) {
 		}
 		send := make(chan []byte)
 		perrs := make(chan error, 1)
-		go p(send, perrs)
+		go p(t.Context(), send, perrs)
 		drainErrs(perrs)
 		return send
 	}
@@ -82,7 +82,7 @@ func TestUnixSocketFanIn(t *testing.T) {
 	}
 	send := make(chan []byte, total)
 	lerrs := make(chan error, 1)
-	go lp(send, lerrs)
+	go lp(t.Context(), send, lerrs)
 	drainErrs(lerrs)
 
 	waitForSocket(t, sockPath)
@@ -101,7 +101,7 @@ func TestUnixSocketFanIn(t *testing.T) {
 			recv := make(chan []byte, msgsPerWriter)
 			cerrs := make(chan error, msgsPerWriter)
 			cdone := make(chan struct{})
-			go sw(recv, cerrs, cdone)
+			go sw(t.Context(), recv, cerrs, cdone)
 			drainErrs(cerrs)
 
 			for m := 0; m < msgsPerWriter; m++ {

--- a/stdlib/integration/file_follow_test.go
+++ b/stdlib/integration/file_follow_test.go
@@ -29,7 +29,7 @@ func TestFileFollowTail(t *testing.T) {
 	}
 	send := make(chan []byte, N)
 	perrs := make(chan error, 1)
-	go p(send, perrs)
+	go p(t.Context(), send, perrs)
 	drainErrs(perrs)
 
 	// Append N lines with a delay that forces the tail reader to wake from its
@@ -73,7 +73,7 @@ func TestFileFollowExistingContent(t *testing.T) {
 	}
 	send := make(chan []byte, 8)
 	perrs := make(chan error, 1)
-	go p(send, perrs)
+	go p(t.Context(), send, perrs)
 	drainErrs(perrs)
 
 	// Collect the 3 pre-existing lines first.

--- a/stdlib/integration/http_request_test.go
+++ b/stdlib/integration/http_request_test.go
@@ -51,7 +51,7 @@ func TestHTTPRequestConsumer(t *testing.T) {
 	recv := make(chan []byte)
 	cerrs := make(chan error, 1)
 	cdone := make(chan struct{})
-	go c(recv, cerrs, cdone)
+	go c(t.Context(), recv, cerrs, cdone)
 	drainErrs(cerrs)
 
 	want := make([]string, N)
@@ -100,7 +100,7 @@ func TestHTTPRequestConsumerErrorOnBadStatus(t *testing.T) {
 	recv := make(chan []byte, 1)
 	cerrs := make(chan error, 1)
 	cdone := make(chan struct{})
-	go c(recv, cerrs, cdone)
+	go c(t.Context(), recv, cerrs, cdone)
 
 	recv <- []byte("trigger-error")
 	close(recv)

--- a/stdlib/integration/http_webhook_test.go
+++ b/stdlib/integration/http_webhook_test.go
@@ -33,7 +33,7 @@ func TestHTTPWebhookReceiver(t *testing.T) {
 	// requests are in flight.
 	send := make(chan []byte, N)
 	errs := make(chan error, N)
-	go p(send, errs)
+	go p(t.Context(), send, errs)
 	drainErrs(errs)
 
 	waitForHTTP(t, "http://"+addr+"/hook")
@@ -83,7 +83,7 @@ func TestHTTPWebhookBodyCap(t *testing.T) {
 	}
 	send := make(chan []byte, 2)
 	errs := make(chan error, 1)
-	go p(send, errs)
+	go p(t.Context(), send, errs)
 	drainErrs(errs)
 
 	waitForHTTP(t, "http://"+addr+"/ingest")
@@ -136,7 +136,7 @@ func TestHTTPWebhookMethodGating(t *testing.T) {
 	}
 	send := make(chan []byte, 4)
 	errs := make(chan error, 1)
-	go p(send, errs)
+	go p(t.Context(), send, errs)
 	drainErrs(errs)
 
 	waitForHTTP(t, "http://"+addr+"/ingest")

--- a/stdlib/integration/socket_meta_test.go
+++ b/stdlib/integration/socket_meta_test.go
@@ -24,7 +24,7 @@ func TestSocketMetaRoundTrip(t *testing.T) {
 	}
 	send := make(chan []byte)
 	lerrs := make(chan error, 1)
-	go lp(send, lerrs)
+	go lp(t.Context(), send, lerrs)
 	drainErrs(lerrs)
 
 	waitForSocket(t, sockPath)
@@ -36,7 +36,7 @@ func TestSocketMetaRoundTrip(t *testing.T) {
 	recv := make(chan []byte)
 	cerrs := make(chan error, 1)
 	cdone := make(chan struct{})
-	go cw(recv, cerrs, cdone)
+	go cw(t.Context(), recv, cerrs, cdone)
 	drainErrs(cerrs)
 
 	want := []string{

--- a/stdlib/integration/tcp_fanin_test.go
+++ b/stdlib/integration/tcp_fanin_test.go
@@ -29,7 +29,7 @@ func TestTCPFanIn(t *testing.T) {
 	}
 	send := make(chan []byte, total)
 	lerrs := make(chan error, 1)
-	go lp(send, lerrs)
+	go lp(t.Context(), send, lerrs)
 	drainErrs(lerrs)
 
 	waitForTCP(t, addr)
@@ -51,7 +51,7 @@ func TestTCPFanIn(t *testing.T) {
 			recv := make(chan []byte, msgsPerWriter)
 			cerrs := make(chan error, msgsPerWriter)
 			cdone := make(chan struct{})
-			go cw(recv, cerrs, cdone)
+			go cw(t.Context(), recv, cerrs, cdone)
 			drainErrs(cerrs)
 
 			for m := 0; m < msgsPerWriter; m++ {
@@ -96,7 +96,7 @@ func TestTCPFanInSequential(t *testing.T) {
 	}
 	send := make(chan []byte, rounds*msgsPerRound)
 	lerrs := make(chan error, 1)
-	go lp(send, lerrs)
+	go lp(t.Context(), send, lerrs)
 	drainErrs(lerrs)
 
 	waitForTCP(t, addr)
@@ -110,7 +110,7 @@ func TestTCPFanInSequential(t *testing.T) {
 		recv := make(chan []byte, msgsPerRound)
 		cerrs := make(chan error, msgsPerRound)
 		cdone := make(chan struct{})
-		go cw(recv, cerrs, cdone)
+		go cw(t.Context(), recv, cerrs, cdone)
 		drainErrs(cerrs)
 
 		for m := 0; m < msgsPerRound; m++ {

--- a/stdlib/integration/udp_test.go
+++ b/stdlib/integration/udp_test.go
@@ -23,7 +23,7 @@ func TestUDPDatagramTransport(t *testing.T) {
 	}
 	send := make(chan []byte, N)
 	lerrs := make(chan error, 1)
-	go lp(send, lerrs)
+	go lp(t.Context(), send, lerrs)
 	drainErrs(lerrs)
 
 	// Give the goroutine time to call net.ListenPacket and bind before we dial.

--- a/stdlib/produce/constant.go
+++ b/stdlib/produce/constant.go
@@ -1,6 +1,8 @@
 package produce
 
 import (
+	"context"
+
 	"github.com/psyduck-etl/sdk"
 )
 
@@ -16,12 +18,16 @@ func Constant(parse sdk.Parser) (sdk.Producer, error) {
 	}
 
 	value := []byte(config.Value)
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 
 		for i := 0; config.StopAfter == 0 || i < config.StopAfter; i++ {
-			send <- value
+			select {
+			case send <- value:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}, nil
 }

--- a/stdlib/produce/constant.go
+++ b/stdlib/produce/constant.go
@@ -25,6 +25,7 @@ func Constant(parse sdk.Parser) (sdk.Producer, error) {
 		for i := 0; config.StopAfter == 0 || i < config.StopAfter; i++ {
 			select {
 			case send <- value:
+				continue
 			case <-ctx.Done():
 				return
 			}

--- a/stdlib/produce/dev.go
+++ b/stdlib/produce/dev.go
@@ -118,6 +118,7 @@ func Ticker(parse sdk.Parser) (sdk.Producer, error) {
 			}
 			select {
 			case <-tick.C:
+				continue
 			case <-ctx.Done():
 				return
 			}

--- a/stdlib/produce/dev.go
+++ b/stdlib/produce/dev.go
@@ -1,6 +1,7 @@
 package produce
 
 import (
+	"context"
 	"strconv"
 	"time"
 
@@ -25,13 +26,17 @@ func Sequence(parse sdk.Parser) (sdk.Producer, error) {
 		step = 1
 	}
 
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 
 		n := config.Start
 		for i := 0; config.StopAfter == 0 || i < config.StopAfter; i++ {
-			send <- []byte(strconv.Itoa(n))
+			select {
+			case send <- []byte(strconv.Itoa(n)):
+			case <-ctx.Done():
+				return
+			}
 			n += step
 		}
 	}, nil
@@ -51,14 +56,18 @@ func Generate(parse sdk.Parser) (sdk.Producer, error) {
 		return nil, err
 	}
 
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 
 		emitted := 0
 		for {
 			for _, v := range config.Values {
-				send <- []byte(v)
+				select {
+				case send <- []byte(v):
+				case <-ctx.Done():
+					return
+				}
 				emitted++
 				if config.StopAfter > 0 && emitted >= config.StopAfter {
 					return
@@ -93,7 +102,7 @@ func Ticker(parse sdk.Parser) (sdk.Producer, error) {
 		format = "unix-ms"
 	}
 
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 
@@ -102,8 +111,16 @@ func Ticker(parse sdk.Parser) (sdk.Producer, error) {
 
 		for i := 0; config.StopAfter == 0 || i < config.StopAfter; i++ {
 			now := time.Now()
-			send <- []byte(formatTime(now, format))
-			<-tick.C
+			select {
+			case send <- []byte(formatTime(now, format)):
+			case <-ctx.Done():
+				return
+			}
+			select {
+			case <-tick.C:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}, nil
 }

--- a/stdlib/produce/file.go
+++ b/stdlib/produce/file.go
@@ -1,6 +1,7 @@
 package produce
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,21 @@ import (
 
 	"github.com/gastrodon/psyduck/stdlib/transport"
 )
+
+// closeOnDone closes c the moment ctx ends, unless the returned stop fires
+// first. It exists to unblock a synchronous, otherwise uncancellable Read()
+// on a reader/connection/listener when the producer's ctx is cancelled.
+func closeOnDone(ctx context.Context, c io.Closer) (stop func()) {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			c.Close()
+		case <-done:
+		}
+	}()
+	return func() { close(done) }
+}
 
 type fileConfig struct {
 	Location     string  `psy:"location"`
@@ -45,7 +61,7 @@ func File(parse sdk.Parser) (sdk.Producer, error) {
 		return nil, err
 	}
 
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 
@@ -69,10 +85,20 @@ func File(parse sdk.Parser) (sdk.Producer, error) {
 		}
 		defer closer.Close()
 
+		// closing the reader on cancellation unblocks a Read() that's
+		// waiting on data (or a follow-mode sleep) with no message ready
+		// to route the ctx.Done() check below through.
+		stop := closeOnDone(ctx, closer)
+		defer stop()
+
 		if err := d.Split(reader, func(b []byte) error {
-			send <- b
-			return nil
-		}); err != nil {
+			select {
+			case send <- b:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}); err != nil && ctx.Err() == nil {
 			errs <- err
 		}
 	}, nil

--- a/stdlib/produce/http_listen.go
+++ b/stdlib/produce/http_listen.go
@@ -1,6 +1,7 @@
 package produce
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -31,7 +32,7 @@ func HTTPListen(parse sdk.Parser) (sdk.Producer, error) {
 		return nil, err
 	}
 
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 
@@ -55,7 +56,12 @@ func HTTPListen(parse sdk.Parser) (sdk.Producer, error) {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-			send <- body
+			select {
+			case send <- body:
+			case <-ctx.Done():
+				http.Error(w, "shutting down", http.StatusServiceUnavailable)
+				return
+			}
 			w.WriteHeader(config.Status)
 			if config.Reply != "" {
 				_, _ = io.WriteString(w, config.Reply)
@@ -69,7 +75,10 @@ func HTTPListen(parse sdk.Parser) (sdk.Producer, error) {
 			WriteTimeout: time.Duration(config.WriteTimeoutMs) * time.Millisecond,
 			IdleTimeout:  time.Duration(config.IdleTimeoutMs) * time.Millisecond,
 		}
-		if err := srv.ListenAndServe(); err != nil {
+		stop := closeOnDone(ctx, srv)
+		defer stop()
+
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errs <- err
 		}
 	}, nil

--- a/stdlib/produce/listen.go
+++ b/stdlib/produce/listen.go
@@ -1,6 +1,7 @@
 package produce
 
 import (
+	"context"
 	"net"
 	"strings"
 	"sync"
@@ -46,7 +47,7 @@ func Listen(parse sdk.Parser) (sdk.Producer, error) {
 }
 
 func listenStream(location string, create bool, d transport.Delimit) sdk.Producer {
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 
@@ -56,6 +57,12 @@ func listenStream(location string, create bool, d transport.Delimit) sdk.Produce
 			return
 		}
 		defer ln.Close()
+
+		// unblocks Accept() on cancellation; stops accepting new
+		// connections but leaves already-accepted ones to finish via
+		// their own closeOnDone below.
+		stop := closeOnDone(ctx, ln)
+		defer stop()
 
 		var wg sync.WaitGroup
 		for {
@@ -67,9 +74,15 @@ func listenStream(location string, create bool, d transport.Delimit) sdk.Produce
 			go func(c net.Conn) {
 				defer wg.Done()
 				defer c.Close()
+				connStop := closeOnDone(ctx, c)
+				defer connStop()
 				_ = d.Split(c, func(b []byte) error {
-					send <- b
-					return nil
+					select {
+					case send <- b:
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
+					}
 				})
 			}(conn)
 		}
@@ -78,7 +91,7 @@ func listenStream(location string, create bool, d transport.Delimit) sdk.Produce
 }
 
 func listenPacket(location string, d transport.Delimit) sdk.Producer {
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 
@@ -89,6 +102,9 @@ func listenPacket(location string, d transport.Delimit) sdk.Producer {
 		}
 		defer pc.Close()
 
+		stop := closeOnDone(ctx, pc)
+		defer stop()
+
 		buf := make([]byte, 64*1024)
 		for {
 			n, _, err := pc.ReadFrom(buf)
@@ -97,7 +113,11 @@ func listenPacket(location string, d transport.Delimit) sdk.Producer {
 			}
 			msg := make([]byte, n)
 			copy(msg, buf[:n])
-			send <- msg
+			select {
+			case send <- msg:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }

--- a/stdlib/produce/listen.go
+++ b/stdlib/produce/listen.go
@@ -115,6 +115,7 @@ func listenPacket(location string, d transport.Delimit) sdk.Producer {
 			copy(msg, buf[:n])
 			select {
 			case send <- msg:
+				continue
 			case <-ctx.Done():
 				return
 			}

--- a/stdlib/produce/produce_test.go
+++ b/stdlib/produce/produce_test.go
@@ -51,7 +51,9 @@ func mustStop(t *testing.T, p func(context.Context, chan<- []byte, chan<- error)
 	for {
 		select {
 		case <-send:
+			continue
 		case <-errs:
+			continue
 		case <-done:
 			return
 		case <-deadline:

--- a/stdlib/produce/produce_test.go
+++ b/stdlib/produce/produce_test.go
@@ -1,0 +1,93 @@
+package produce
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// parser builds an sdk.Parser that populates a struct's psy-tagged fields
+// from vals via reflection, the same stand-in stdlib/integration uses to
+// stay independent of the HCL config layer.
+func parser(vals map[string]any) func(dst any) error {
+	return func(dst any) error {
+		rv := reflect.ValueOf(dst).Elem()
+		rt := rv.Type()
+		for i := 0; i < rt.NumField(); i++ {
+			tag := rt.Field(i).Tag.Get("psy")
+			if tag == "" {
+				continue
+			}
+			v, ok := vals[tag]
+			if !ok || v == nil {
+				continue
+			}
+			rv.Field(i).Set(reflect.ValueOf(v))
+		}
+		return nil
+	}
+}
+
+// mustStop runs p under a cancelled-shortly context and fails the test if
+// it doesn't return (both channels closed) within the bound — a hang here
+// means the producer isn't actually selecting on ctx.Done().
+func mustStop(t *testing.T, p func(context.Context, chan<- []byte, chan<- error)) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	send, errs := make(chan []byte), make(chan error)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p(ctx, send, errs)
+	}()
+
+	// drain whatever the producer sends, same as a real consumer would,
+	// until it signals done by returning (which it can only do here via
+	// its deferred close(send)/close(errs) once ctx ends).
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-send:
+		case <-errs:
+		case <-done:
+			return
+		case <-deadline:
+			t.Fatal("producer did not stop after ctx cancellation")
+		}
+	}
+}
+
+func TestConstant_StopsOnCancel(t *testing.T) {
+	p, err := Constant(parser(map[string]any{"value": "x", "stop-after": 0}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustStop(t, p)
+}
+
+func TestSequence_StopsOnCancel(t *testing.T) {
+	p, err := Sequence(parser(map[string]any{"start": 0, "step": 1, "stop-after": 0}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustStop(t, p)
+}
+
+func TestGenerate_StopsOnCancel(t *testing.T) {
+	p, err := Generate(parser(map[string]any{"values": []string{"a", "b"}, "loop": true, "stop-after": 0}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustStop(t, p)
+}
+
+func TestTicker_StopsOnCancel(t *testing.T) {
+	p, err := Ticker(parser(map[string]any{"interval-ms": 1, "format": "unix-ms", "stop-after": 0}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustStop(t, p)
+}

--- a/stdlib/produce/request.go
+++ b/stdlib/produce/request.go
@@ -48,6 +48,7 @@ func Request(parse sdk.Parser) (sdk.Producer, error) {
 			if interval > 0 {
 				select {
 				case <-time.After(interval):
+					continue
 				case <-ctx.Done():
 					return
 				}

--- a/stdlib/produce/request.go
+++ b/stdlib/produce/request.go
@@ -1,6 +1,7 @@
 package produce
 
 import (
+	"context"
 	"time"
 
 	"github.com/psyduck-etl/sdk"
@@ -25,20 +26,31 @@ func Request(parse sdk.Parser) (sdk.Producer, error) {
 	}
 	interval := time.Duration(config.IntervalMs) * time.Millisecond
 
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 
 		client := h.Client()
 		for {
-			data, err := h.Do(client, body)
+			data, err := h.Do(ctx, client, body)
 			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
 				errs <- err
 				return
 			}
-			send <- data
+			select {
+			case send <- data:
+			case <-ctx.Done():
+				return
+			}
 			if interval > 0 {
-				time.Sleep(interval)
+				select {
+				case <-time.After(interval):
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}, nil

--- a/stdlib/produce/socket.go
+++ b/stdlib/produce/socket.go
@@ -1,6 +1,8 @@
 package produce
 
 import (
+	"context"
+
 	"github.com/psyduck-etl/sdk"
 
 	"github.com/gastrodon/psyduck/stdlib/transport"
@@ -33,7 +35,7 @@ func Socket(parse sdk.Parser) (sdk.Producer, error) {
 		return nil, err
 	}
 
-	return func(send chan<- []byte, errs chan<- error) {
+	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
 		defer close(errs)
 
@@ -44,10 +46,17 @@ func Socket(parse sdk.Parser) (sdk.Producer, error) {
 		}
 		defer rc.Close()
 
+		stop := closeOnDone(ctx, rc)
+		defer stop()
+
 		if err := d.Split(rc, func(b []byte) error {
-			send <- b
-			return nil
-		}); err != nil {
+			select {
+			case send <- b:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}); err != nil && ctx.Err() == nil {
 			errs <- err
 		}
 	}, nil

--- a/stdlib/transport/http.go
+++ b/stdlib/transport/http.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -63,8 +64,10 @@ func (h HTTP) Client() *http.Client {
 }
 
 // Do issues one request with the given body (nil for none) and returns the
-// response body. A status code outside SuccessCodes is an error.
-func (h HTTP) Do(client *http.Client, body []byte) ([]byte, error) {
+// response body. A status code outside SuccessCodes is an error. ctx bounds
+// the request — cancelling it aborts an in-flight Do promptly instead of
+// waiting out the client's timeout.
+func (h HTTP) Do(ctx context.Context, client *http.Client, body []byte) ([]byte, error) {
 	target, err := url.Parse(h.URL)
 	if err != nil {
 		return nil, fmt.Errorf("http: bad url %q: %w", h.URL, err)
@@ -86,7 +89,7 @@ func (h HTTP) Do(client *http.Client, body []byte) ([]byte, error) {
 	if method == "" {
 		method = http.MethodGet
 	}
-	req, err := http.NewRequest(method, target.String(), reader)
+	req, err := http.NewRequestWithContext(ctx, method, target.String(), reader)
 	if err != nil {
 		return nil, fmt.Errorf("http: build request: %w", err)
 	}


### PR DESCRIPTION
# Summary

Reimagines the concurrency core around three ideas: `context.Context` cancellation end-to-end, `iter.Seq2[[]byte, error]` as the merged producer stream, and standard fan-in/fan-out patterns (`sync.WaitGroup`, ctx-aware selects) in place of the hand-rolled `join()` counter machinery.

Fixes #8, fixes #10, fixes #11, fixes #12, fixes #19 — and the in-repo half of #9.

## Design

**One hard constraint:** `sdk.Producer`/`sdk.Consumer` are channel-based function types from the external `psyduck-etl/sdk` module, so plugins keep their contract untouched. The engine bridges those channels into modern machinery at its boundary.

### `core/stream.go` — producers as an `iter.Seq2`

`produce(ctx, producers)` merges N producers into a single `iter.Seq2[[]byte, error]`. Internally each producer gets fresh channels and two forwarder goroutines feeding an unbuffered `chan result` (a private `{msg, err}` pair — the Rust-style Result stays transport; the Seq2 *is* the API). Termination is layered:

- A producer **completes** when it closes its data channel — detected with two-value receives, so a legitimately-nil `[]byte` no longer kills the stream (#12).
- Error forwarders don't require plugins to close `errs` (the sdk doesn't mandate it): once every data channel has closed, a `dataDone` signal makes them sweep pending errors and exit. Errors emitted *before* a producer completes are guaranteed delivered; errors after data-close are best-effort by necessity.
- A `WaitGroup` pair gates `close(merged)` so no sender can outlive the channel — and the engine never closes a channel a plugin writes to, which eliminates #19's send-on-closed panic hazard outright.
- The Seq2 derives its own cancellable context, so breaking out of the `range` (ExitOnError, stop-after, all consumers finished) unwinds every forwarder.

### `core/sink.go` — consumers with `done` awareness

Fan-out sends select on each consumer's `done` alongside the send: a consumer that finishes early (e.g. a `stop-after` wrapper) is dropped from the fan-out instead of blocking the pipeline forever (#10), and when the last one finishes the run ends early. I deliberately did **not** take issue #10's drain-and-discard sketch for `flow.Consumer` — discarding would make engine sends keep "succeeding" into the void, hiding the cutoff and running producers to exhaustion; honoring `done` stops the pipeline instead.

### `core/run.go` — the loop

```go
for msg, err := range produce(ctx, pipeline.Producers) { ... }
```

Transform, fan out, count. `ExitOnError` records the first error and cancels; every engine goroutine is released before `RunPipeline` returns (#11). Pipeline-level `stop-after` — previously parsed into the struct but **never read by the old run loop** — is now enforced (behavior change: configs using it went from "ignored, potentially hang" to "works").

`joinProducers`, `joinConsumers`, `join`, and `mchan` are deleted.

### parse layer (#9, in-repo half; #8)

- `Parser.Parse(ctx, ...)` and `ResourceFunc(ctx, max)` — draining can do real work (a `produce-from` seed runs a producer), so it takes the caller's context.
- `drainSeed` uses the caller's deadline, falling back to the old 10s `remoteTimeout` only when none is set, and a seed closing without sending is now `produce-from X: seed producer closed without sending` instead of silently parsing as empty config (#8).
- `main.go` wires `signal.NotifyContext(SIGINT, SIGTERM)` through everything — Ctrl-C winds pipelines down cleanly.

### Known limitation

A plugin goroutine abandoned mid-send parks on its last write — the sdk contract has no cancellation hook. That's bounded (one goroutine per plugin), panic-free, and is the remaining sdk-side half of #9.

## Testing

- New regression tests for each issue: nil-message passthrough (#12), consumer stop-after no-deadlock (#10), late-error no-panic (#19), goroutine-boundedness across completed runs (#11/#19), seed closed-without-send and seed deadline (#8/#9), plus matrix/filter/error/cancel coverage.
- `go test -race -count=3` clean on core, flow, and parse.
- Driven end-to-end at the CLI, old binary vs new on identical configs:
  - consumer `stop-after = 2` under 1000 messages: **main hangs (timeout kill); this branch exits 0 with exactly 2 messages**
  - pipeline `stop-after = 4` over an infinite producer: **main hangs; this branch exits 0 with `0..3`**
  - SIGINT on an infinite pipeline: unwound in ~2ms
  - `exit-on-error` with a missing-file producer: attributed error, exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZFhLfJNez3RpES6JEYezA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZFhLfJNez3RpES6JEYezA)_