### PR TITLE
HTTP API, stage 1: single-instance control/observability (psyduck serve)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ psyduck <command> <file>.psy [args]
 | `list [--stat] <file>` | List the file's pipelines by name. `--stat` adds `r<producers> x<transformers> c<consumers>` and an `r` flag when `produce-from` is used. |
 | `show <file> [name ...]` | Print resource references and evaluated config for each pipeline. |
 | `init <file>` | Fetch and compile every `plugin {}` reachable from the file (including through imports), content-address the built binaries into `.psyduck/`, and write `<file>.lock`. Required before `run`/`list`/`show` will work — see [above](#using-an-external-plugin). |
+| `serve [--addr]` | Run the HTTP control/observability API as a long-running daemon (takes no file). Observe running pipelines, dispatch new ones, and expose JSON + Prometheus metrics. See [`docs/http-api.md`](docs/http-api.md). Single-instance today; peer-to-peer is a planned stage 2. |
 
 Set `PSYDUCK_LOG_LEVEL` to `trace`/`debug`/`warn`/`error`/`fatal`/`panic` to
 change runtime log verbosity.
@@ -164,6 +165,9 @@ change runtime log verbosity.
 - [`docs/plugins.md`](docs/plugins.md) — writing plugins in Go: the
   `sdk.Plugin` interface, `Spec` fields, `psy` struct tags, and how psyduck
   loads binaries.
+- [`docs/http-api.md`](docs/http-api.md) — the `psyduck serve` HTTP API:
+  observe running pipelines, dispatch new ones, and expose JSON + Prometheus
+  metrics (single-instance; peer-to-peer is a planned stage 2).
 - [`examples/`](examples/) — `.psy` fixtures exercised by the test suite, one
   file per example. `shared.psy` holds consumers reused across the others;
   files that want them declare their own `import { shared = "shared.psy" }`.
@@ -178,3 +182,4 @@ change runtime log verbosity.
 | `plugins` | `Store` — clones, builds, and content-addresses external plugins into `.psyduck/`; `Lock`/`ReadLock`/`WriteLock` for the per-file `.lock` format. |
 | `stdlib` | The built-in plugin. Always loaded; no `plugin {}` block needed. |
 | `core` | `BuildPipeline`, `RunPipeline` — turns a parsed pipeline into a running one. |
+| `server` | HTTP control/observability API for `psyduck serve`; talks only to a `Supervisor` interface (see [`docs/http-api.md`](docs/http-api.md)). |

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ psyduck <command> <file>.psy [args]
 | `list [--stat] <file>` | List the file's pipelines by name. `--stat` adds `r<producers> x<transformers> c<consumers>` and an `r` flag when `produce-from` is used. |
 | `show <file> [name ...]` | Print resource references and evaluated config for each pipeline. |
 | `init <file>` | Fetch and compile every `plugin {}` reachable from the file (including through imports), content-address the built binaries into `.psyduck/`, and write `<file>.lock`. Required before `run`/`list`/`show` will work — see [above](#using-an-external-plugin). |
-| `serve [--addr] [--plugin-dir]` | Run the HTTP control/observability API as a long-running daemon (takes no file). Observe running pipelines, dispatch new ones, register plugins, and expose JSON + Prometheus metrics. See [`docs/http-api.md`](docs/http-api.md). Single-instance today; peer-to-peer is a planned stage 2. |
+| `serve [--addr] [--plugin-dir] [--basic-auth]` | Run the HTTP control/observability API as a long-running daemon (takes no file). Observe running pipelines, dispatch new ones, register plugins (guarded by `--basic-auth user:pass`), and expose JSON + Prometheus metrics. See [`docs/http-api.md`](docs/http-api.md). Single-instance today; peer-to-peer is a planned stage 2. |
 
 Set `PSYDUCK_LOG_LEVEL` to `trace`/`debug`/`warn`/`error`/`fatal`/`panic` to
 change runtime log verbosity.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ psyduck <command> <file>.psy [args]
 | `list [--stat] <file>` | List the file's pipelines by name. `--stat` adds `r<producers> x<transformers> c<consumers>` and an `r` flag when `produce-from` is used. |
 | `show <file> [name ...]` | Print resource references and evaluated config for each pipeline. |
 | `init <file>` | Fetch and compile every `plugin {}` reachable from the file (including through imports), content-address the built binaries into `.psyduck/`, and write `<file>.lock`. Required before `run`/`list`/`show` will work — see [above](#using-an-external-plugin). |
-| `serve [--addr]` | Run the HTTP control/observability API as a long-running daemon (takes no file). Observe running pipelines, dispatch new ones, and expose JSON + Prometheus metrics. See [`docs/http-api.md`](docs/http-api.md). Single-instance today; peer-to-peer is a planned stage 2. |
+| `serve [--addr] [--plugin-dir]` | Run the HTTP control/observability API as a long-running daemon (takes no file). Observe running pipelines, dispatch new ones, register plugins, and expose JSON + Prometheus metrics. See [`docs/http-api.md`](docs/http-api.md). Single-instance today; peer-to-peer is a planned stage 2. |
 
 Set `PSYDUCK_LOG_LEVEL` to `trace`/`debug`/`warn`/`error`/`fatal`/`panic` to
 change runtime log verbosity.

--- a/README.md
+++ b/README.md
@@ -183,3 +183,4 @@ change runtime log verbosity.
 | `stdlib` | The built-in plugin. Always loaded; no `plugin {}` block needed. |
 | `core` | `BuildPipeline`, `RunPipeline` — turns a parsed pipeline into a running one. |
 | `server` | HTTP control/observability API for `psyduck serve`; talks only to a `Supervisor` interface (see [`docs/http-api.md`](docs/http-api.md)). |
+| `supervise` | Live `server.Supervisor`: parses, builds, and runs dispatched pipelines with `core`, and reports their status and stats. |

--- a/core/build.go
+++ b/core/build.go
@@ -22,6 +22,11 @@ type Pipeline struct {
 	logger      *logrus.Logger
 	StopAfter   int
 	ExitOnError bool
+	// Stats accumulates live counters as the pipeline runs. BuildPipeline
+	// always sets it; RunPipeline bumps it. A caller that wants to observe
+	// a running pipeline (see the server/supervise packages) holds onto
+	// this pointer and reads Stats.Snapshot() concurrently.
+	Stats *Stats
 }
 
 func pipelineLogger() *logrus.Logger {
@@ -152,5 +157,6 @@ func BuildPipeline(ctx context.Context, src parse.Pipeline, plugins []sdk.Plugin
 		logger:      logger,
 		StopAfter:   src.StopAfter,
 		ExitOnError: src.ExitOnError,
+		Stats:       &Stats{},
 	}, nil
 }

--- a/core/run.go
+++ b/core/run.go
@@ -33,9 +33,15 @@ func RunPipeline(outer context.Context, pipeline *Pipeline) error {
 		logger = pipelineLogger()
 	}
 
+	stats := pipeline.Stats
+	if stats == nil {
+		stats = &Stats{} // never bump a nil; a caller that skipped Build still runs
+	}
+
 	var failMu sync.Mutex
 	var failure error
 	report := func(err error) {
+		stats.errors.Add(1)
 		logger.Error(err)
 		if pipeline.ExitOnError {
 			failMu.Lock()
@@ -60,6 +66,7 @@ func RunPipeline(outer context.Context, pipeline *Pipeline) error {
 			report(fmt.Errorf("producer supplied error: %w", err))
 			continue
 		}
+		stats.produced.Add(1)
 
 		transformed, err := transform(msg)
 		if err != nil {
@@ -67,12 +74,15 @@ func RunPipeline(outer context.Context, pipeline *Pipeline) error {
 			continue
 		}
 		if transformed == nil {
+			stats.filtered.Add(1)
 			continue // filtered out
 		}
+		stats.transformed.Add(1)
 
 		if !consumers.send(ctx, transformed) {
 			break // every consumer finished, or ctx ended
 		}
+		stats.delivered.Add(1)
 
 		delivered++
 		if pipeline.StopAfter > 0 && delivered >= pipeline.StopAfter {

--- a/core/stats.go
+++ b/core/stats.go
@@ -1,0 +1,49 @@
+package core
+
+import "sync/atomic"
+
+// Stats holds live counters for one running pipeline. RunPipeline bumps the
+// fields as messages flow; an observer (the HTTP supervisor) reads a
+// consistent copy with Snapshot while the pipeline is still running. All
+// access is atomic, so a *Stats can be shared across goroutines without
+// further locking.
+//
+// The counters correspond to the observable events in RunPipeline's loop:
+// a message is Produced, then it is Filtered (a transformer dropped it),
+// Transformed (it passed the whole stack) and Delivered (handed to
+// consumers), or it turns into an Error. Errors also counts producer- and
+// consumer-side errors, which have no Produced/Delivered of their own.
+type Stats struct {
+	produced    atomic.Uint64
+	transformed atomic.Uint64
+	filtered    atomic.Uint64
+	delivered   atomic.Uint64
+	errors      atomic.Uint64
+}
+
+// StatsSnapshot is an immutable copy of a Stats at one instant, safe to
+// hand outside the engine.
+type StatsSnapshot struct {
+	Produced    uint64
+	Transformed uint64
+	Filtered    uint64
+	Delivered   uint64
+	Errors      uint64
+}
+
+// Snapshot reads every counter. The reads are individually atomic but not
+// mutually consistent — a snapshot taken mid-flight may show a message
+// counted as produced but not yet delivered, which is exactly the in-flight
+// state a lag gauge wants.
+func (s *Stats) Snapshot() StatsSnapshot {
+	if s == nil {
+		return StatsSnapshot{}
+	}
+	return StatsSnapshot{
+		Produced:    s.produced.Load(),
+		Transformed: s.transformed.Load(),
+		Filtered:    s.filtered.Load(),
+		Delivered:   s.delivered.Load(),
+		Errors:      s.errors.Load(),
+	}
+}

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -92,6 +92,11 @@ Base path `/api/v1`. Everything is JSON except [`/metrics`](#metrics).
 | `GET` | `/api/v1/pipelines/{id}/stats` | Just the stats block, for cheap polling. |
 | `DELETE` | `/api/v1/pipelines/{id}` | Cancel a running/pending pipeline. |
 | `GET` | `/api/v1/graph` | Node/edge projection of everything running. |
+| `GET` | `/api/v1/plugins` | List the instance's plugin manifest. |
+| `POST` | `/api/v1/plugins` | **Register** a plugin (clone + compile into the store). `202 Accepted`. |
+| `GET` | `/api/v1/plugins/{name}` | One plugin's manifest: its resources and their options. |
+| `PUT` | `/api/v1/plugins/{name}` | **Update** a plugin's source/tag and rebuild. `202 Accepted`. |
+| `DELETE` | `/api/v1/plugins/{name}` | **Remove** a plugin from the manifest. |
 | `GET` | `/metrics` | Prometheus/OpenMetrics exposition. |
 | `GET` | `/api/v1/peers` | **Stage 2.** Returns `501` today. |
 
@@ -236,6 +241,103 @@ each edge carries the message count that has crossed it.
 }
 ```
 
+### Plugins
+
+An instance ships with the stdlib resources. To let dispatched jobs use an
+external plugin (amqp, mysql, ifunny, …), you register it with the instance —
+and this is deliberately a **store/manifest operation, not an in-process
+load**. A running node doesn't hold every plugin resident forever; instead it
+keeps a *manifest* (name → source, ref, hash) and the compiled `.so` in a
+content-addressed store, and a **job loads the plugins it needs at dispatch**.
+
+The model, in one breath: managing plugins edits what *future* jobs can use;
+a dispatched job must carry a `plugin {}` block that matches the manifest,
+exactly like a `.psy` file needs its lock for `psyduck run`; and editing the
+manifest never disturbs a pipeline already running (it holds the plugin
+snapshot it was dispatched with).
+
+**Register** — `POST /api/v1/plugins`, mirroring a `plugin {}` block:
+
+```json
+{ "name": "amqp", "source": "https://github.com/psyduck-etl/amqp", "tag": "v0.1.0" }
+```
+
+This clones + compiles the plugin and content-addresses the binary into the
+store (`--plugin-dir`, default `.psyduck/`) — a partial, on-demand `psyduck
+init` scoped to one plugin. It's slow (network + `go build`), so it's
+asynchronous: `202 Accepted`, status `loading`, then `ready` (built, in the
+store) or `failed` (with the build error). `ready` means *available to jobs*,
+not *resident in the process*.
+
+**List / manifest** — `GET /api/v1/plugins` returns every manifest entry with
+its status; `GET /api/v1/plugins/{name}` returns the full manifest — the
+resources the plugin offers and every option each accepts:
+
+```json
+{
+  "name": "amqp",
+  "source": "https://github.com/psyduck-etl/amqp",
+  "ref": "refs/tags/v0.1.0",
+  "status": "ready",
+  "resources": [
+    {
+      "name": "amqp-queue",
+      "kinds": ["produce", "consume"],
+      "options": [
+        {"name": "connection", "type": "string", "required": true},
+        {"name": "queue", "type": "string", "required": true}
+      ]
+    }
+  ]
+}
+```
+
+Reading the manifest is the one operation that *opens* the binary (a plugin's
+resources are only knowable from the loaded plugin) — so it's what first makes
+a plugin resident; the handle is then cached.
+
+**Update** — `PUT /api/v1/plugins/{name}` re-points a plugin at a new
+`source`/`tag` and rebuilds it into the store. **Delete** —
+`DELETE /api/v1/plugins/{name}` removes it from the manifest so new jobs can
+no longer declare it. Both are file/manifest operations; both leave running
+pipelines untouched.
+
+**Using it** — a dispatched job declares the plugin and uses its resources:
+
+```hcl
+plugin "amqp" {
+  source = "https://github.com/psyduck-etl/amqp"
+  tag    = "v0.1.0"
+}
+
+produce "amqp-queue" "in" {
+  connection = "amqp://guest:guest@localhost:5672/"
+  queue      = "work"
+}
+
+consume "file" "out" { location = "-" }
+
+pipeline "drain" {
+  produce = [produce.amqp-queue.in]
+  consume = [consume.file.out]
+}
+```
+
+At dispatch the instance resolves the `plugin {}` block against its manifest,
+loads that binary from the store, and builds the pipeline with it. A job that
+names a plugin the instance doesn't have — or whose source/tag doesn't match
+the manifest — is rejected with a clear error.
+
+> **The one hard constraint: Go plugins can't be unloaded or reloaded.** Once
+> a `.so` is opened it stays resident for the life of the process. So
+> *delete* frees the manifest, not the memory, and *update* can't hot-swap a
+> plugin a job has already loaded: the rebuilt binary lands in the store and
+> the record is flagged `restart_required`, taking effect for new jobs after
+> a restart. This is why registration is a store operation and loading is
+> per-job — it keeps the unavoidable residency scoped to what's actually been
+> used, and keeps add/list/update/delete honest as file operations. Freeing
+> orphaned store binaries (a `psyduck` store-GC) is a follow-up.
+
 ## Runtime shape
 
 `psyduck serve` is a long-running daemon. Its layers:
@@ -280,17 +382,30 @@ The API observes and runs real pipelines:
   pipeline and computes `in_flight`; `server` marshals it to JSON and
   `/metrics`.
 
+- **Plugin manifest.** The supervisor keeps a manifest of plugins (see
+  [Plugins](#plugins)). `AddPlugin`/`UpdatePlugin` build a spec into the
+  content-addressed `plugins.Store` (via `store.Build`) — asynchronously,
+  since it clones and compiles — and record the resolved ref/hash;
+  `RemovePlugin` drops the manifest entry. Dispatch extracts a job's
+  `plugin{}` blocks (`hcl…Plugins`), resolves them against the manifest, and
+  loads just those from the store (`store.Load`) for that job. Opened
+  binaries are cached by content hash, since Go can't unload them.
+
 `StubSupervisor` stays as the fixture the `server` package tests against —
 same interface, representative data, no runtime.
 
 ### Still to wire (follow-ups)
 
-- **External plugins over the wire.** Dispatched pipelines resolve against
-  `stdlib` only; a `plugin{}` block needs the clone/compile store flow
-  (`psyduck init`) the serve path doesn't run yet. A source that references
-  an external plugin fails at build with a clear "no plugin loaded" error.
-- **Persistence.** Terminal pipelines live in memory; a restart forgets them.
-- **Auth.** Still none — see [Open questions](#open-questions).
+- **Persistence.** The manifest and terminal pipelines live in memory; a
+  restart forgets them (the store's compiled binaries do persist on disk).
+  Persisting the manifest is what makes an update's `restart_required` fully
+  meaningful.
+- **Store GC.** `DELETE` removes a plugin from the manifest but leaves its
+  content-addressed binary in the store cache; a `psyduck` store-GC to reap
+  unreferenced binaries is a follow-up.
+- **Auth.** Still none — see [Open questions](#open-questions). Plugin
+  registration runs `git clone` + `go build`, so it needs auth at least as
+  much as dispatch.
 - **Per-resource stats.** Counters are per-pipeline; per-stage attribution
   (which transformer drops, which consumer errors) wants the counter keyed by
   resource ref.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -8,10 +8,10 @@ This document is the design for **stage 1 — everything that concerns a single
 instance**. Peer-to-peer (siblings, job splitting) is [stage 2](#stage-2-peers),
 sketched at the end but deliberately not built yet.
 
-The API ships today as a **compiling skeleton**: every route exists and
-returns correctly-shaped data, backed by a stub. What's stubbed and what's
-real is called out throughout, and the runtime work to make it live is in
-[Wiring it live](#wiring-it-live).
+The API is **live**: `psyduck serve` parses, builds, and runs dispatched
+pipelines through the real engine, and reports their status and stats as they
+run. What's wired and what's still a follow-up is called out in
+[What's wired](#whats-wired-this-pr).
 
 ## Why an API at all
 
@@ -242,55 +242,61 @@ each edge carries the message count that has crossed it.
 
 ```
  HTTP router (server.Server)      routes + JSON/Prometheus marshaling; no runtime types
+        │  server.Supervisor (interface)
+        ▼
+ supervise.Supervisor            owns pipelines; parses/builds/runs; List/Get/Dispatch/Cancel/…
         │
         ▼
- Supervisor (interface)           owns pipelines; List/Get/Dispatch/Cancel/Graph/Instance
-        │
-        ▼
- core.BuildPipeline / RunPipeline unchanged engine, one goroutine per pipeline
+ core.BuildPipeline / RunPipeline the engine, one goroutine per pipeline; counters wired in
 ```
 
 The **`server` package never imports `core` or `parse`** — it talks only to a
-`Supervisor` interface. That boundary is the whole point: it lets the exact
-same routes serve a stub today and a live supervisor tomorrow, and keeps the
-HTTP concerns (status codes, payload shapes) testable without standing up a
+`Supervisor` interface. That boundary is the whole point, and it holds even
+now that the API is live: the concrete `supervise.Supervisor` imports `core`,
+`parse`, and `stdlib`; `server` imports none of them. The same routes serve
+either the live supervisor (`psyduck serve`) or the in-memory `StubSupervisor`
+(HTTP-layer tests), and the HTTP concerns stay testable without standing up a
 pipeline.
 
-### What's real vs. stubbed today
+### What's wired (this PR)
 
-**Real:** the router, every route and status code, the JSON payload types,
-the Prometheus exposition, the graph projection (`buildGraph`, a pure
-function the live supervisor reuses verbatim), graceful shutdown on
-SIGINT/SIGTERM, and the full test suite (`server/server_test.go`).
+The API observes and runs real pipelines:
 
-**Stubbed:** `StubSupervisor` is in-memory. It seeds two representative
-pipelines, records a `pending` pipeline on dispatch (running nothing), and
-honors cancel. It never parses `source`, builds a `core.Pipeline`, or moves a
-counter on its own. Everything it returns has the exact shape the live
-implementation will — so a UI, a Grafana dashboard, or a client can be built
-against it now.
+- **`supervise.Supervisor`** (new package) implements `server.Supervisor`.
+  `Dispatch` parses `source` with `hcl.NewParserHCL()` against an in-memory
+  loader, requires exactly one `pipeline{}` block, and — asynchronously —
+  calls `core.BuildPipeline` and `core.RunPipeline` in a goroutine under a
+  cancelable child of the serve context. `Cancel` cancels it; terminal state
+  (`succeeded`/`failed`/`canceled`) and any error come from `RunPipeline`'s
+  return. Topology is extracted from the parsed `parse.PipelineSpec` at
+  dispatch time, so it's visible before the run finishes. `psyduck serve` now
+  runs this, not the stub.
+- **Stats in `core`.** `core.Stats` is a set of `atomic.Uint64` counters on
+  `core.Pipeline`; `RunPipeline` bumps them at each observable event
+  (produced / transformed / filtered / delivered / errors), and
+  `Stats.Snapshot()` reads a copy concurrently. The change is additive — a
+  nil `Stats` means "don't count", so the CLI `run` path and any caller that
+  skips `BuildPipeline` are unaffected. The supervisor reads a snapshot per
+  pipeline and computes `in_flight`; `server` marshals it to JSON and
+  `/metrics`.
 
-### Wiring it live
+`StubSupervisor` stays as the fixture the `server` package tests against —
+same interface, representative data, no runtime.
 
-Turning the stub into a real supervisor is the follow-up, in two pieces:
+### Still to wire (follow-ups)
 
-1. **A live `Supervisor`.** Holds a map of `id → running pipeline`. `Dispatch`
-   parses `source` with `hcl.NewParserHCL()`, calls `core.BuildPipeline`,
-   assigns an id, and runs it in its own goroutine under a cancelable context;
-   `Cancel` cancels that context; `List`/`Get` read the map. Terminal state
-   and `error` come from `RunPipeline`'s return.
+- **External plugins over the wire.** Dispatched pipelines resolve against
+  `stdlib` only; a `plugin{}` block needs the clone/compile store flow
+  (`psyduck init`) the serve path doesn't run yet. A source that references
+  an external plugin fails at build with a clear "no plugin loaded" error.
+- **Persistence.** Terminal pipelines live in memory; a restart forgets them.
+- **Auth.** Still none — see [Open questions](#open-questions).
+- **Per-resource stats.** Counters are per-pipeline; per-stage attribution
+  (which transformer drops, which consumer errors) wants the counter keyed by
+  resource ref.
 
-2. **Instrumentation in `core`.** The stats counters need a home. `RunPipeline`
-   already sees every event — it increments `delivered`, calls `report(err)`,
-   and knows when `transform` returns `nil` (filtered). The minimal hook is an
-   optional counter sink on the pipeline (e.g. a `core.Stats` struct of
-   `atomic.Uint64`s the loop bumps, exposed via a getter). The supervisor
-   reads that snapshot for each pipeline; `server` marshals it. This is the
-   only change outside the `server` package, and it's additive — a nil sink
-   means "don't count", so `psyduck run` is unaffected.
-
-Neither piece changes any route or payload, which is why they're safe to
-defer: the contract in this document is already fixed.
+None of these change a route or payload — the contract in this document is
+fixed.
 
 ## Stage 2: peers
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -177,9 +177,11 @@ alternative can come later without changing the route.)
 
 > **Security.** Dispatch runs arbitrary pipeline config on the instance,
 > which can read files, open sockets, and load plugins. It is **not**
-> authenticated in this skeleton — bind `serve` to a private interface / mesh
-> and put auth (token, mTLS) in front before exposing it. Auth is called out
-> as a follow-up in [Open questions](#open-questions), not designed here.
+> authenticated today (only the [plugin routes](#plugins) are, via
+> `--basic-auth`) — bind `serve` to a private interface / mesh and, until
+> dispatch shares the same gate, keep it off any public bind. Extending the
+> Basic-auth guard to dispatch is a one-line change (the middleware is
+> reusable); see [Open questions](#open-questions).
 
 ### Metrics
 
@@ -328,6 +330,15 @@ loads that binary from the store, and builds the pipeline with it. A job that
 names a plugin the instance doesn't have — or whose source/tag doesn't match
 the manifest — is rejected with a clear error.
 
+**Auth.** Because registration clones and compiles operator-supplied sources
+(arbitrary code on the host), the whole `/api/v1/plugins` subtree is gated by
+HTTP Basic auth when `serve --basic-auth user:pass` (or
+`PSYDUCK_SERVE_BASIC_AUTH`) is set — the same `"user:pass"` convention
+stdlib's `request` transport uses. Unset, the routes stay open and `serve`
+logs a warning at startup. A gated request without valid credentials gets
+`401` with a `WWW-Authenticate` challenge; observability, dispatch, and
+`/metrics` are not behind this gate.
+
 > **The one hard constraint: Go plugins can't be unloaded or reloaded.** Once
 > a `.so` is opened it stays resident for the life of the process. So
 > *delete* frees the manifest, not the memory, and *update* can't hot-swap a
@@ -403,9 +414,10 @@ same interface, representative data, no runtime.
 - **Store GC.** `DELETE` removes a plugin from the manifest but leaves its
   content-addressed binary in the store cache; a `psyduck` store-GC to reap
   unreferenced binaries is a follow-up.
-- **Auth.** Still none — see [Open questions](#open-questions). Plugin
-  registration runs `git clone` + `go build`, so it needs auth at least as
-  much as dispatch.
+- **Auth.** The plugin routes are gated by HTTP Basic auth (`--basic-auth`);
+  dispatch/cancel are not yet, though they're just as sensitive. Extending
+  the same guard to them (and, later, tokens/mTLS) is the follow-up — see
+  [Open questions](#open-questions).
 - **Per-resource stats.** Counters are per-pipeline; per-stage attribution
   (which transformer drops, which consumer errors) wants the counter keyed by
   resource ref.
@@ -439,8 +451,11 @@ Reserved endpoints (shape TBD): `GET/POST /api/v1/peers`,
 
 ## Open questions
 
-- **Auth.** None in the skeleton. Token or mTLS in front of `serve`, or a
-  built-in middleware? Dispatch especially needs it before any public bind.
+- **Auth.** The plugin routes have a built-in HTTP Basic guard
+  (`--basic-auth user:pass`, mirroring stdlib's `request` credential format);
+  the reusable middleware lives in `server/auth.go`. Open: extend it to
+  dispatch/cancel (equally sensitive), and whether to add token/mTLS as
+  stronger options in front of `serve`.
 - **Persistence.** Terminal pipelines live in memory; a restart forgets them.
   Do we need a retention window, or a bounded ring of recent runs?
 - **Dispatch payload.** Full `.psy` HCL reuses `parse/hcl` for free but is
@@ -453,10 +468,15 @@ Reserved endpoints (shape TBD): `GET/POST /api/v1/peers`,
 ## Try it
 
 ```sh
-go run . serve --addr :8080
+go run . serve --addr :8080 --basic-auth ops:s3cret
 curl -s localhost:8080/api/v1/instance | jq
 curl -s localhost:8080/api/v1/pipelines | jq
 curl -s -XPOST localhost:8080/api/v1/pipelines \
   -d '{"name":"demo","source":"pipeline \"demo\" {}"}'
 curl -s localhost:8080/metrics
+
+# plugin routes need the credential:
+curl -s -u ops:s3cret localhost:8080/api/v1/plugins | jq
+curl -s -u ops:s3cret -XPOST localhost:8080/api/v1/plugins \
+  -d '{"name":"amqp","source":"https://github.com/psyduck-etl/amqp","tag":"v0.1.0"}'
 ```

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1,0 +1,341 @@
+# HTTP API
+
+A control and observability surface for a running psyduck instance: read
+what pipelines are executing and their stats, dispatch new pipelines to run,
+and expose metrics for Grafana and a graph board.
+
+This document is the design for **stage 1 — everything that concerns a single
+instance**. Peer-to-peer (siblings, job splitting) is [stage 2](#stage-2-peers),
+sketched at the end but deliberately not built yet.
+
+The API ships today as a **compiling skeleton**: every route exists and
+returns correctly-shaped data, backed by a stub. What's stubbed and what's
+real is called out throughout, and the runtime work to make it live is in
+[Wiring it live](#wiring-it-live).
+
+## Why an API at all
+
+psyduck is a CLI: `psyduck run file.psy` builds pipelines and runs them to
+completion. That's the right unit for a one-shot job, but three things want
+more:
+
+- **Workers.** We want to launch psyduck instances as Nomad (or other
+  microservice) workers and hand them jobs at runtime, not bake a `.psy`
+  file into each deploy. That's a long-running process that accepts work over
+  the network — a daemon, not a one-shot command.
+- **Observability.** A self-feeding discovery pipeline flies blind today —
+  no throughput, drop, lag, or error numbers (see
+  [#18](https://github.com/gastrodon/psyduck/issues/18), item 9). A running
+  instance should be able to *tell you* what it's doing.
+- **A graph board.** The producer→transform→consumer shape of a pipeline is
+  a graph; a live instance can expose it as nodes and edges for a board.
+
+The API is one `psyduck serve` daemon that answers all three.
+
+```sh
+psyduck serve --addr :8080
+```
+
+## Model
+
+Two nouns.
+
+**Instance** — one `psyduck serve` process. It has an id, a version, an
+uptime, and owns some pipelines. In stage 2 an instance also knows about
+[peers](#stage-2-peers).
+
+**Pipeline** — one built-and-running (or recently-finished) pipeline the
+instance owns. It has:
+
+- an **id** (assigned by the instance) and a **name** (from its `pipeline {}`
+  block, or a dispatch label);
+- a **status** — `pending` → `running` → one terminal state (`succeeded`,
+  `failed`, `canceled`);
+- a **source** — where it came from: a file the daemon was told to run, or a
+  `dispatch:` label for one POSTed in;
+- a **topology** — the resource refs in each slot (`produce.request.api`, …),
+  in declaration order. This is display metadata only: the API never returns
+  *evaluated* resource config, because that holds secrets (bearer tokens,
+  DSNs). Refs are safe; values are not;
+- **stats** — the counter snapshot below.
+
+### Stats
+
+The counters map onto the observable events in `core.RunPipeline`'s loop —
+one message is produced, then it is filtered, delivered, or errors:
+
+| Field | Meaning |
+|---|---|
+| `produced` | messages emitted by the producers |
+| `transformed` | messages that passed the whole transform stack |
+| `filtered` | messages a transformer dropped (a `nil` result today) |
+| `delivered` | messages handed to the consumers |
+| `errors` | errors reported by any stage |
+| `in_flight` | `produced − (delivered + filtered + errors)` — a coarse lag gauge |
+
+Counters are monotonic within a run. A UI computes **rates** by diffing two
+snapshots over time; Grafana does the same with `rate()`/`increase()` over
+the [`/metrics`](#metrics) series. `in_flight` is the one gauge — it's the
+"is a stage falling behind?" signal issue #18 asked for.
+
+## Endpoints
+
+Base path `/api/v1`. Everything is JSON except [`/metrics`](#metrics).
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/healthz` | Liveness. `{"status":"ok"}`. |
+| `GET` | `/api/v1/instance` | Instance identity + rolled-up pipeline counts. |
+| `GET` | `/api/v1/pipelines` | List every pipeline (running, pending, recently terminal). |
+| `POST` | `/api/v1/pipelines` | **Dispatch** a pipeline to run. `202 Accepted`. |
+| `GET` | `/api/v1/pipelines/{id}` | One pipeline: topology + stats + status. |
+| `GET` | `/api/v1/pipelines/{id}/stats` | Just the stats block, for cheap polling. |
+| `DELETE` | `/api/v1/pipelines/{id}` | Cancel a running/pending pipeline. |
+| `GET` | `/api/v1/graph` | Node/edge projection of everything running. |
+| `GET` | `/metrics` | Prometheus/OpenMetrics exposition. |
+| `GET` | `/api/v1/peers` | **Stage 2.** Returns `501` today. |
+
+Error responses are `{"error": "..."}` with a matching status
+(`400` bad request, `404` not found, `409` not cancelable, `501` peers).
+
+### Observe
+
+`GET /api/v1/instance`:
+
+```json
+{
+  "id": "psyduck-local",
+  "version": "0.1.0-dev",
+  "started_at": "2026-07-10T12:00:00Z",
+  "uptime_seconds": 1.02,
+  "pipelines": { "running": 1, "pending": 0, "succeeded": 1,
+                 "failed": 0, "canceled": 0, "total": 2 }
+}
+```
+
+`GET /api/v1/pipelines/{id}`:
+
+```json
+{
+  "id": "pipe-000001",
+  "name": "ingest",
+  "status": "running",
+  "source": "file:examples/ingest.psy",
+  "topology": {
+    "producers":    [{"ref": "produce.http-listen.hook", "kind": "produce"}],
+    "transformers": [{"ref": "transform.jq.shape", "kind": "transform"},
+                     {"ref": "transform.set.tag",  "kind": "transform"}],
+    "consumers":    [{"ref": "consume.socket.bus",  "kind": "consume"}]
+  },
+  "stats": {"produced": 1280, "transformed": 1204, "filtered": 76,
+            "delivered": 1204, "errors": 2, "in_flight": 0},
+  "created_at": "2026-07-10T12:00:00Z",
+  "started_at": "2026-07-10T12:00:00Z"
+}
+```
+
+A pipeline that uses `produce-from` reports its seed as `topology.remote_seed`
+instead of `producers` — mirroring `parse.PipelineSpec`, which the API view is
+built from.
+
+### Dispatch
+
+`POST /api/v1/pipelines` is the network front door to the pattern psyduck
+already has internally. Today, the [meta-pipeline pattern](patterns.md#meta-pipelines)
+feeds `produce-from` off a socket or queue: one process writes `produce {}`
+blocks, a worker reads and runs them. Dispatch is the same idea with HTTP as
+the transport — an operator (or, in stage 2, a peer) POSTs a whole pipeline
+and the instance runs it.
+
+The body is a complete `.psy` document — the same HCL a `psyduck run` file
+holds — plus advisory metadata:
+
+```json
+{
+  "name": "adhoc-backfill",
+  "source": "produce \"sequence\" \"pages\" { stop-after = 50 }\nconsume \"file\" \"out\" { location = \"-\" }\npipeline \"adhoc\" { produce = [produce.sequence.pages] consume = [consume.file.out] }",
+  "labels": { "run": "manual" }
+}
+```
+
+Response is `202 Accepted` with a `Location: /api/v1/pipelines/{id}` header and
+the created record (status `pending`). The instance parses, builds, and runs
+the pipeline asynchronously; the caller polls `GET .../{id}` (or watches
+`/metrics`) for progress. `DELETE .../{id}` cancels it.
+
+Why a full `.psy` document rather than a JSON pipeline spec? Because it reuses
+`parse/hcl` verbatim — the same strict attribute validation, `env.*`
+resolution, imports, and `plugin {}` handling a file gets — with no second
+schema to keep in sync. (The known sharp edge is that dispatched HCL is
+stringly-typed, exactly the concern in issue #18 item 7; a structured
+alternative can come later without changing the route.)
+
+> **Security.** Dispatch runs arbitrary pipeline config on the instance,
+> which can read files, open sockets, and load plugins. It is **not**
+> authenticated in this skeleton — bind `serve` to a private interface / mesh
+> and put auth (token, mTLS) in front before exposing it. Auth is called out
+> as a follow-up in [Open questions](#open-questions), not designed here.
+
+### Metrics
+
+Two audiences, two formats — that's why we expose both:
+
+- **JSON stats** on the API (`/api/v1/pipelines/{id}/stats`, or the `stats`
+  block on each pipeline) — for a UI / graph board that wants to shape the
+  numbers itself.
+- **Prometheus/OpenMetrics** text at `GET /metrics` — for Grafana. Point a
+  Prometheus data source at the instance; Prometheus *pulls* on a schedule
+  (no push infra to run), and the counters become dashboards.
+
+The exposition is hand-written (no client-library dependency — the format is
+small and stable):
+
+```
+# TYPE psyduck_pipelines gauge
+psyduck_pipelines{status="running"} 1
+# TYPE psyduck_pipeline_messages_produced_total counter
+psyduck_pipeline_messages_produced_total{pipeline="pipe-000001",name="ingest"} 1280
+# TYPE psyduck_pipeline_in_flight gauge
+psyduck_pipeline_in_flight{pipeline="pipe-000001",name="ingest"} 0
+```
+
+| Metric | Type | Labels | |
+|---|---|---|---|
+| `psyduck_build_info` | gauge | `version`, `instance` | always `1` |
+| `psyduck_instance_uptime_seconds` | gauge | — | |
+| `psyduck_pipelines` | gauge | `status` | count by lifecycle state |
+| `psyduck_pipeline_messages_produced_total` | counter | `pipeline`, `name` | |
+| `psyduck_pipeline_messages_transformed_total` | counter | `pipeline`, `name` | |
+| `psyduck_pipeline_messages_filtered_total` | counter | `pipeline`, `name` | |
+| `psyduck_pipeline_messages_delivered_total` | counter | `pipeline`, `name` | |
+| `psyduck_pipeline_errors_total` | counter | `pipeline`, `name` | |
+| `psyduck_pipeline_in_flight` | gauge | `pipeline`, `name` | coarse lag |
+
+A typical Grafana panel is `rate(psyduck_pipeline_messages_delivered_total[1m])`
+per pipeline, with `psyduck_pipeline_in_flight` on a second axis to spot a
+lagging stage.
+
+### Graph board
+
+`GET /api/v1/graph` is a denormalized projection of the same data, shaped for
+a node/edge visualization instead of per-pipeline polling. Each pipeline is a
+container node; each stage is a node wired producer → transform → consumer;
+each edge carries the message count that has crossed it.
+
+```json
+{
+  "nodes": [
+    {"id": "pipe-000001", "kind": "pipeline", "label": "ingest", "status": "running",
+     "stats": {"produced": 1280, "delivered": 1204, "...": 0}},
+    {"id": "pipe-000001:produce:0",   "kind": "produce",   "label": "produce.http-listen.hook", "pipeline": "pipe-000001"},
+    {"id": "pipe-000001:transform:0", "kind": "transform", "label": "transform.jq.shape",        "pipeline": "pipe-000001"}
+  ],
+  "edges": [
+    {"from": "pipe-000001:produce:0", "to": "pipe-000001:transform:0", "messages": 1204}
+  ]
+}
+```
+
+## Runtime shape
+
+`psyduck serve` is a long-running daemon. Its layers:
+
+```
+ HTTP router (server.Server)      routes + JSON/Prometheus marshaling; no runtime types
+        │
+        ▼
+ Supervisor (interface)           owns pipelines; List/Get/Dispatch/Cancel/Graph/Instance
+        │
+        ▼
+ core.BuildPipeline / RunPipeline unchanged engine, one goroutine per pipeline
+```
+
+The **`server` package never imports `core` or `parse`** — it talks only to a
+`Supervisor` interface. That boundary is the whole point: it lets the exact
+same routes serve a stub today and a live supervisor tomorrow, and keeps the
+HTTP concerns (status codes, payload shapes) testable without standing up a
+pipeline.
+
+### What's real vs. stubbed today
+
+**Real:** the router, every route and status code, the JSON payload types,
+the Prometheus exposition, the graph projection (`buildGraph`, a pure
+function the live supervisor reuses verbatim), graceful shutdown on
+SIGINT/SIGTERM, and the full test suite (`server/server_test.go`).
+
+**Stubbed:** `StubSupervisor` is in-memory. It seeds two representative
+pipelines, records a `pending` pipeline on dispatch (running nothing), and
+honors cancel. It never parses `source`, builds a `core.Pipeline`, or moves a
+counter on its own. Everything it returns has the exact shape the live
+implementation will — so a UI, a Grafana dashboard, or a client can be built
+against it now.
+
+### Wiring it live
+
+Turning the stub into a real supervisor is the follow-up, in two pieces:
+
+1. **A live `Supervisor`.** Holds a map of `id → running pipeline`. `Dispatch`
+   parses `source` with `hcl.NewParserHCL()`, calls `core.BuildPipeline`,
+   assigns an id, and runs it in its own goroutine under a cancelable context;
+   `Cancel` cancels that context; `List`/`Get` read the map. Terminal state
+   and `error` come from `RunPipeline`'s return.
+
+2. **Instrumentation in `core`.** The stats counters need a home. `RunPipeline`
+   already sees every event — it increments `delivered`, calls `report(err)`,
+   and knows when `transform` returns `nil` (filtered). The minimal hook is an
+   optional counter sink on the pipeline (e.g. a `core.Stats` struct of
+   `atomic.Uint64`s the loop bumps, exposed via a getter). The supervisor
+   reads that snapshot for each pipeline; `server` marshals it. This is the
+   only change outside the `server` package, and it's additive — a nil sink
+   means "don't count", so `psyduck run` is unaffected.
+
+Neither piece changes any route or payload, which is why they're safe to
+defer: the contract in this document is already fixed.
+
+## Stage 2: peers
+
+Out of scope for this PR, reserved so the shape is visible. A `Peer` type
+exists in the `server` package and `GET /api/v1/peers` answers `501` (not
+`404` — the route is planned, just unavailable).
+
+The use case: one instance gets a job, learns about its siblings, and
+distributes parts of the job across them. Open design questions for the next
+round:
+
+- **Discovery** — how does an instance learn its peers? Static config, a
+  Nomad/Consul service catalog, or gossip?
+- **Identity & health** — `GET /api/v1/instance` is already the "who are you"
+  handshake a peer would call; peers add a liveness/heartbeat notion on top.
+- **Job splitting** — how is one job partitioned? The natural fit is the
+  existing dispatch surface: a coordinator splits work into N `.psy` documents
+  and POSTs each to a peer's `/api/v1/pipelines` — peer distribution as
+  fan-out over the stage-1 dispatch endpoint, no new runtime concept.
+- **Aggregation & backpressure** — where do partial results land, and how does
+  a slow peer signal it?
+
+Reserved endpoints (shape TBD): `GET/POST /api/v1/peers`,
+`POST /api/v1/peers/{id}/dispatch`.
+
+## Open questions
+
+- **Auth.** None in the skeleton. Token or mTLS in front of `serve`, or a
+  built-in middleware? Dispatch especially needs it before any public bind.
+- **Persistence.** Terminal pipelines live in memory; a restart forgets them.
+  Do we need a retention window, or a bounded ring of recent runs?
+- **Dispatch payload.** Full `.psy` HCL reuses `parse/hcl` for free but is
+  stringly-typed (issue #18 item 7). A structured variant can be added behind
+  the same route later.
+- **Per-stage stats.** Counters are per-pipeline today. Per-resource stats
+  (which transformer is dropping? which consumer errors?) need the
+  instrumentation hook to key by resource ref.
+
+## Try it
+
+```sh
+go run . serve --addr :8080
+curl -s localhost:8080/api/v1/instance | jq
+curl -s localhost:8080/api/v1/pipelines | jq
+curl -s -XPOST localhost:8080/api/v1/pipelines \
+  -d '{"name":"demo","source":"pipeline \"demo\" {}"}'
+curl -s localhost:8080/metrics
+```

--- a/main.go
+++ b/main.go
@@ -257,10 +257,32 @@ func show(ctx *cli.Context) error {
 // winds down both the server and every running pipeline. Plugins added over
 // the API are cloned/compiled into the --plugin-dir store and loaded per job.
 func serve(ctx *cli.Context) error {
+	opts, err := authOptions(ctx.String("basic-auth"))
+	if err != nil {
+		return err
+	}
+
 	sup := supervise.New(ctx.Context, ctx.String("plugin-dir"))
 	addr := ctx.String("addr")
 	fmt.Printf("psyduck serve: listening on %s\n", addr)
-	return server.New(sup).ListenAndServe(ctx.Context, addr)
+	return server.New(sup, opts...).ListenAndServe(ctx.Context, addr)
+}
+
+// authOptions turns the --basic-auth "user:pass" flag into server options,
+// mirroring the credential format stdlib's request transport uses. An empty
+// value leaves the plugin routes open — with a warning, since registration
+// clones and compiles arbitrary sources.
+func authOptions(cred string) ([]server.Option, error) {
+	if cred == "" {
+		fmt.Println("psyduck serve: WARNING plugin routes are unauthenticated; set --basic-auth user:pass (or PSYDUCK_SERVE_BASIC_AUTH)")
+		return nil, nil
+	}
+	user, pass, ok := strings.Cut(cred, ":")
+	if !ok || user == "" || pass == "" {
+		return nil, fmt.Errorf(`--basic-auth must be "user:pass"`)
+	}
+	fmt.Println("psyduck serve: plugin routes require basic auth")
+	return []server.Option{server.WithBasicAuth(user, pass)}, nil
 }
 
 func main() {
@@ -317,6 +339,11 @@ func main() {
 						Name:  "plugin-dir",
 						Value: ".psyduck",
 						Usage: "content-addressed store dir for plugins added over the api",
+					},
+					&cli.StringFlag{
+						Name:    "basic-auth",
+						Usage:   `protect plugin routes with HTTP Basic auth, "user:pass"`,
+						EnvVars: []string{"PSYDUCK_SERVE_BASIC_AUTH"},
 					},
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gastrodon/psyduck/parse"
 	"github.com/gastrodon/psyduck/parse/hcl"
 	"github.com/gastrodon/psyduck/plugins"
+	"github.com/gastrodon/psyduck/server"
 	"github.com/gastrodon/psyduck/stdlib"
 	"github.com/gastrodon/psyduck/stdlib/data"
 )
@@ -247,6 +248,20 @@ func show(ctx *cli.Context) error {
 	return nil
 }
 
+// serve starts the single-instance HTTP API (see the server package and
+// docs/http-api.md). Unlike the other commands it takes no pipeline file:
+// it's a long-running daemon that observes and dispatches pipelines over
+// HTTP. Today it runs against a stub supervisor returning representative
+// data — wiring it to a live, pipeline-owning supervisor is the documented
+// follow-up. It serves until ctx is canceled (SIGINT/SIGTERM), then shuts
+// down gracefully.
+func serve(ctx *cli.Context) error {
+	sup := server.NewStubSupervisor()
+	addr := ctx.String("addr")
+	fmt.Printf("psyduck serve: listening on %s (stub supervisor)\n", addr)
+	return server.New(sup).ListenAndServe(ctx.Context, addr)
+}
+
 func main() {
 	app := cli.App{
 		Name:  "psyduck",
@@ -286,6 +301,18 @@ func main() {
 				Args:      true,
 				ArgsUsage: "pipeline file",
 				Flags:     []cli.Flag{},
+			},
+			{
+				Name:   "serve",
+				Usage:  "run the http api server (single-instance; peers are WIP)",
+				Action: serve,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "addr",
+						Value: ":8080",
+						Usage: "address to listen on",
+					},
+				},
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gastrodon/psyduck/server"
 	"github.com/gastrodon/psyduck/stdlib"
 	"github.com/gastrodon/psyduck/stdlib/data"
+	"github.com/gastrodon/psyduck/supervise"
 )
 
 // init installs the process-wide codec factory sdk.GetCodec resolves
@@ -251,14 +252,15 @@ func show(ctx *cli.Context) error {
 // serve starts the single-instance HTTP API (see the server package and
 // docs/http-api.md). Unlike the other commands it takes no pipeline file:
 // it's a long-running daemon that observes and dispatches pipelines over
-// HTTP. Today it runs against a stub supervisor returning representative
-// data — wiring it to a live, pipeline-owning supervisor is the documented
-// follow-up. It serves until ctx is canceled (SIGINT/SIGTERM), then shuts
-// down gracefully.
+// HTTP. It runs against a live supervisor that parses, builds, and runs
+// dispatched .psy documents with core, sharing ctx.Context so SIGINT/SIGTERM
+// winds down both the server and every running pipeline. Dispatched
+// pipelines resolve against stdlib (external plugin{} loading over the wire
+// is a follow-up).
 func serve(ctx *cli.Context) error {
-	sup := server.NewStubSupervisor()
+	sup := supervise.New(ctx.Context)
 	addr := ctx.String("addr")
-	fmt.Printf("psyduck serve: listening on %s (stub supervisor)\n", addr)
+	fmt.Printf("psyduck serve: listening on %s\n", addr)
 	return server.New(sup).ListenAndServe(ctx.Context, addr)
 }
 

--- a/main.go
+++ b/main.go
@@ -254,11 +254,10 @@ func show(ctx *cli.Context) error {
 // it's a long-running daemon that observes and dispatches pipelines over
 // HTTP. It runs against a live supervisor that parses, builds, and runs
 // dispatched .psy documents with core, sharing ctx.Context so SIGINT/SIGTERM
-// winds down both the server and every running pipeline. Dispatched
-// pipelines resolve against stdlib (external plugin{} loading over the wire
-// is a follow-up).
+// winds down both the server and every running pipeline. Plugins added over
+// the API are cloned/compiled into the --plugin-dir store and loaded per job.
 func serve(ctx *cli.Context) error {
-	sup := supervise.New(ctx.Context)
+	sup := supervise.New(ctx.Context, ctx.String("plugin-dir"))
 	addr := ctx.String("addr")
 	fmt.Printf("psyduck serve: listening on %s\n", addr)
 	return server.New(sup).ListenAndServe(ctx.Context, addr)
@@ -313,6 +312,11 @@ func main() {
 						Name:  "addr",
 						Value: ":8080",
 						Usage: "address to listen on",
+					},
+					&cli.StringFlag{
+						Name:  "plugin-dir",
+						Value: ".psyduck",
+						Usage: "content-addressed store dir for plugins added over the api",
 					},
 				},
 			},

--- a/server/auth.go
+++ b/server/auth.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"crypto/subtle"
+	"net/http"
+)
+
+// Option configures a Server at construction. Options are applied before
+// routes are wired, so they can influence which routes are protected.
+type Option func(*Server)
+
+// WithBasicAuth protects the plugin-management routes with HTTP Basic auth,
+// using the same "user:pass" credential convention as stdlib's request
+// transport (see stdlib/transport/http.go). Passing an empty user and pass
+// leaves auth disabled — the zero value — so a caller can apply it
+// unconditionally.
+//
+// Plugin registration runs `git clone` + `go build` on operator-supplied
+// input, so it's the one part of the API that must not be open on an
+// exposed bind; this is the gate for it.
+func WithBasicAuth(user, pass string) Option {
+	return func(s *Server) {
+		s.authUser = user
+		s.authPass = pass
+	}
+}
+
+// authEnabled reports whether any credential was configured.
+func (s *Server) authEnabled() bool {
+	return s.authUser != "" || s.authPass != ""
+}
+
+// guard wraps h to require valid Basic credentials when auth is configured;
+// with no credentials it is a passthrough, so unprotected routes and the
+// auth-disabled case share one code path. Credential comparison is
+// constant-time to avoid leaking the secret through timing.
+func (s *Server) guard(h http.HandlerFunc) http.HandlerFunc {
+	if !s.authEnabled() {
+		return h
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		userOK := subtle.ConstantTimeCompare([]byte(user), []byte(s.authUser)) == 1
+		passOK := subtle.ConstantTimeCompare([]byte(pass), []byte(s.authPass)) == 1
+		if !ok || !userOK || !passOK {
+			w.Header().Set("WWW-Authenticate", `Basic realm="psyduck", charset="UTF-8"`)
+			writeError(w, http.StatusUnauthorized, "authentication required")
+			return
+		}
+		h(w, r)
+	}
+}

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func authServer() *Server {
+	return New(newStubSupervisor(fixedClock()), WithBasicAuth("ops", "s3cret"))
+}
+
+// doWithAuth issues a request carrying optional Basic credentials.
+func doWithAuth(t *testing.T, srv *Server, method, path, user, pass string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(method, path, nil)
+	if user != "" || pass != "" {
+		r.SetBasicAuth(user, pass)
+	}
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, r)
+	return w
+}
+
+func TestPluginRoutesRequireAuth(t *testing.T) {
+	srv := authServer()
+
+	// No credentials -> 401 with a challenge.
+	w := doWithAuth(t, srv, http.MethodGet, "/api/v1/plugins", "", "")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("no creds: got %d, want 401", w.Code)
+	}
+	if ch := w.Header().Get("WWW-Authenticate"); ch == "" {
+		t.Error("missing WWW-Authenticate challenge")
+	}
+
+	// Wrong credentials -> 401.
+	if w := doWithAuth(t, srv, http.MethodGet, "/api/v1/plugins", "ops", "nope"); w.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong creds: got %d, want 401", w.Code)
+	}
+
+	// Correct credentials -> 200.
+	if w := doWithAuth(t, srv, http.MethodGet, "/api/v1/plugins", "ops", "s3cret"); w.Code != http.StatusOK {
+		t.Fatalf("good creds: got %d, want 200", w.Code)
+	}
+}
+
+func TestWriteRoutesRequireAuth(t *testing.T) {
+	srv := authServer()
+	// A mutating plugin route is guarded too.
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/plugins", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated add: got %d, want 401", w.Code)
+	}
+}
+
+func TestNonPluginRoutesStayOpen(t *testing.T) {
+	srv := authServer()
+	// Observability/health remain reachable without credentials, so a UI or
+	// a Prometheus scrape isn't blocked by the plugin gate.
+	for _, path := range []string{"/healthz", "/api/v1/instance", "/api/v1/pipelines", "/metrics"} {
+		if w := doWithAuth(t, srv, http.MethodGet, path, "", ""); w.Code != http.StatusOK {
+			t.Errorf("%s without creds: got %d, want 200", path, w.Code)
+		}
+	}
+}
+
+func TestAuthDisabledLeavesPluginsOpen(t *testing.T) {
+	// The default stub server has no credentials configured.
+	srv := newTestServer()
+	if w := doWithAuth(t, srv, http.MethodGet, "/api/v1/plugins", "", ""); w.Code != http.StatusOK {
+		t.Fatalf("auth-disabled plugins: got %d, want 200", w.Code)
+	}
+}

--- a/server/doc.go
+++ b/server/doc.go
@@ -1,0 +1,25 @@
+/*
+Package server is the HTTP control/observability surface for a single
+psyduck instance.
+
+It is deliberately split from the pipeline runtime: everything here talks to
+a [Supervisor], an interface that owns whatever pipelines this instance is
+running and answers questions about them. The HTTP layer only marshals — it
+never touches core, parse, or the plugin store directly. That boundary is
+what lets the same routes serve a stub today (see [StubSupervisor]) and a
+live, pipeline-owning supervisor once the runtime grows one (see
+docs/http-api.md, "Wiring it live").
+
+Scope: this package is the *single-instance* API — observe the pipelines
+this process runs, dispatch new ones to it, and expose metrics. Peer-to-peer
+(an instance learning about siblings and splitting a job across them) is a
+deliberate second stage; the peer types and the /api/v1/peers route exist
+here only as reserved, not-yet-implemented placeholders so the shape is
+visible while the design is settled.
+*/
+package server
+
+// Version is the API/instance version reported by GET /api/v1/instance and
+// the /metrics build info. It tracks the HTTP surface, not the psyduck
+// binary as a whole.
+const Version = "0.1.0-dev"

--- a/server/doc.go
+++ b/server/doc.go
@@ -6,9 +6,10 @@ It is deliberately split from the pipeline runtime: everything here talks to
 a [Supervisor], an interface that owns whatever pipelines this instance is
 running and answers questions about them. The HTTP layer only marshals — it
 never touches core, parse, or the plugin store directly. That boundary is
-what lets the same routes serve a stub today (see [StubSupervisor]) and a
-live, pipeline-owning supervisor once the runtime grows one (see
-docs/http-api.md, "Wiring it live").
+what lets the same routes serve either the live, pipeline-owning supervisor
+(package supervise, used by `psyduck serve`) or the in-memory
+[StubSupervisor] this package's own tests run against — the HTTP layer can't
+tell them apart.
 
 Scope: this package is the *single-instance* API — observe the pipelines
 this process runs, dispatch new ones to it, and expose metrics. Peer-to-peer

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// handleMetrics serves the Prometheus/OpenMetrics text exposition at
+// GET /metrics. This is the Grafana-facing surface: point a Prometheus
+// scrape at it and the pipeline counters become dashboards. It carries the
+// same numbers as the JSON stats endpoints, in the format a metrics stack
+// expects, because the two audiences differ — a UI wants JSON it can shape,
+// a scraper wants labeled counters it can range over.
+//
+// The exposition is written by hand rather than via a client library so the
+// module stays dependency-free; the format is small and stable.
+func (s *Server) handleMetrics(w http.ResponseWriter, _ *http.Request) {
+	inst := s.sup.Instance()
+	pipelines := s.sup.List()
+
+	var b strings.Builder
+
+	writeMetricHeader(&b, "psyduck_build_info", "gauge", "Instance build/version info; value is always 1.")
+	b.WriteString("psyduck_build_info{version=" + quote(inst.Version) + ",instance=" + quote(inst.ID) + "} 1\n")
+
+	writeMetricHeader(&b, "psyduck_instance_uptime_seconds", "gauge", "Seconds since this instance started serving.")
+	b.WriteString("psyduck_instance_uptime_seconds " + strconv.FormatFloat(inst.UptimeSeconds, 'f', 3, 64) + "\n")
+
+	writeMetricHeader(&b, "psyduck_pipelines", "gauge", "Pipelines known to this instance, by status.")
+	c := inst.Pipelines
+	for _, kv := range []struct {
+		status string
+		n      int
+	}{
+		{"running", c.Running}, {"pending", c.Pending}, {"succeeded", c.Succeeded},
+		{"failed", c.Failed}, {"canceled", c.Canceled},
+	} {
+		b.WriteString("psyduck_pipelines{status=" + quote(kv.status) + "} " + strconv.Itoa(kv.n) + "\n")
+	}
+
+	// Per-pipeline counters. A UI diffs these snapshots for rates; Grafana
+	// does the same with rate()/increase(). in_flight is a gauge (lag).
+	counters := []struct {
+		name, help string
+		get        func(Stats) uint64
+	}{
+		{"psyduck_pipeline_messages_produced_total", "Messages emitted by a pipeline's producers.", func(s Stats) uint64 { return s.Produced }},
+		{"psyduck_pipeline_messages_transformed_total", "Messages that passed the transform stack.", func(s Stats) uint64 { return s.Transformed }},
+		{"psyduck_pipeline_messages_filtered_total", "Messages dropped by a transformer.", func(s Stats) uint64 { return s.Filtered }},
+		{"psyduck_pipeline_messages_delivered_total", "Messages delivered to consumers.", func(s Stats) uint64 { return s.Delivered }},
+		{"psyduck_pipeline_errors_total", "Errors reported by any stage.", func(s Stats) uint64 { return s.Errors }},
+	}
+	for _, m := range counters {
+		writeMetricHeader(&b, m.name, "counter", m.help)
+		for _, p := range pipelines {
+			b.WriteString(m.name + pipelineLabels(p) + " " + strconv.FormatUint(m.get(p.Stats), 10) + "\n")
+		}
+	}
+
+	writeMetricHeader(&b, "psyduck_pipeline_in_flight", "gauge", "Messages produced but not yet delivered/filtered/errored (coarse lag).")
+	for _, p := range pipelines {
+		b.WriteString("psyduck_pipeline_in_flight" + pipelineLabels(p) + " " + strconv.FormatInt(p.Stats.InFlight, 10) + "\n")
+	}
+
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(b.String()))
+}
+
+// pipelineLabels renders the common {pipeline,name} label set for a series.
+func pipelineLabels(p PipelineInfo) string {
+	return "{pipeline=" + quote(p.ID) + ",name=" + quote(p.Name) + "}"
+}
+
+func writeMetricHeader(b *strings.Builder, name, typ, help string) {
+	b.WriteString("# HELP " + name + " " + help + "\n")
+	b.WriteString("# TYPE " + name + " " + typ + "\n")
+}
+
+// quote renders a Prometheus label value: double-quoted with backslash,
+// double-quote, and newline escaped, per the exposition format.
+func quote(v string) string {
+	r := strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`)
+	return `"` + r.Replace(v) + `"`
+}

--- a/server/plugins.go
+++ b/server/plugins.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+// maxPluginBody caps a plugin request body. A plugin spec is a name, a
+// source URL, and a tag — tiny.
+const maxPluginBody = 64 << 10
+
+// PluginStatus is the lifecycle state of a plugin in the instance's
+// manifest. Registering a plugin means cloning + compiling it into the
+// content-addressed store (a partial `psyduck init`) — a file operation that
+// takes real time, so it is asynchronous like a dispatch. "ready" means the
+// binary is built and available for jobs to load; it does not mean the
+// plugin is resident in the process (loading happens per job, at dispatch).
+type PluginStatus string
+
+const (
+	PluginLoading PluginStatus = "loading" // clone/build into the store in progress
+	PluginReady   PluginStatus = "ready"   // built and in the store; jobs may declare it
+	PluginFailed  PluginStatus = "failed"  // clone/build failed (see Error)
+)
+
+// PluginRequest is the body of POST /api/v1/plugins (add) and
+// PUT /api/v1/plugins/{name} (update). It mirrors a `plugin {}` block:
+// a name, a git URL or local path, and an optional ref to check out.
+type PluginRequest struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Tag    string `json:"tag,omitempty"`
+}
+
+// PluginInfo is the list/summary view of a loaded (or loading) plugin.
+type PluginInfo struct {
+	Name   string       `json:"name"`
+	Source string       `json:"source"`
+	Tag    string       `json:"tag,omitempty"` // requested ref, if any
+	Ref    string       `json:"ref,omitempty"` // ref actually resolved at build
+	Hash   string       `json:"hash,omitempty"`
+	Status PluginStatus `json:"status"`
+	Error  string       `json:"error,omitempty"`
+	// Resources is the count this plugin exposes; the full manifest is on
+	// GET /api/v1/plugins/{name}.
+	Resources int `json:"resources"`
+	// RestartRequired is set when an update rebuilt the binary but couldn't
+	// activate it in-process — Go plugins can't be unloaded or reloaded, so
+	// the new version is staged in the store and takes effect on restart
+	// while the currently-loaded one keeps serving.
+	RestartRequired bool       `json:"restart_required,omitempty"`
+	AddedAt         time.Time  `json:"added_at"`
+	LoadedAt        *time.Time `json:"loaded_at,omitempty"`
+}
+
+// PluginManifest is the detail view (GET /api/v1/plugins/{name}): the
+// resources a plugin offers and every config option each accepts. This is
+// the "what can I configure" surface a UI or a pipeline author reads before
+// writing a `produce`/`transform`/`consume` block against the plugin.
+type PluginManifest struct {
+	Name      string           `json:"name"`
+	Source    string           `json:"source"`
+	Ref       string           `json:"ref,omitempty"`
+	Status    PluginStatus     `json:"status"`
+	Resources []PluginResource `json:"resources"`
+}
+
+// PluginResource is one resource a plugin offers — a producer, transformer,
+// and/or consumer — and its configurable options.
+type PluginResource struct {
+	Name    string         `json:"name"`
+	Kinds   []string       `json:"kinds"` // any of "produce", "transform", "consume"
+	Options []PluginOption `json:"options"`
+}
+
+// PluginOption describes one configuration field of a resource. It is the
+// API projection of sdk.Spec: nested list/map element types surface as Elem,
+// object fields as Fields.
+type PluginOption struct {
+	Name        string         `json:"name"`
+	Type        string         `json:"type"`
+	Description string         `json:"description,omitempty"`
+	Required    bool           `json:"required,omitempty"`
+	Default     any            `json:"default,omitempty"`
+	Elem        *PluginOption  `json:"elem,omitempty"`
+	Fields      []PluginOption `json:"fields,omitempty"`
+}
+
+// Plugin management error sentinels. Handlers map these onto status codes.
+var (
+	ErrPluginNotFound = errors.New("plugin not found")
+	ErrPluginExists   = errors.New("plugin already loaded")
+	ErrInvalidPlugin  = errors.New("plugin name and source are required")
+)
+
+// --- handlers ---------------------------------------------------------------
+
+func (s *Server) handleListPlugins(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"plugins": s.sup.Plugins()})
+}
+
+func (s *Server) handleGetPlugin(w http.ResponseWriter, r *http.Request) {
+	m, ok := s.sup.Plugin(r.PathValue("name"))
+	if !ok {
+		writeError(w, http.StatusNotFound, "no such plugin")
+		return
+	}
+	writeJSON(w, http.StatusOK, m)
+}
+
+func (s *Server) handleAddPlugin(w http.ResponseWriter, r *http.Request) {
+	var req PluginRequest
+	if err := decodeJSON(r, &req, maxPluginBody); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	p, err := s.sup.AddPlugin(req)
+	switch {
+	case err == nil:
+		w.Header().Set("Location", "/api/v1/plugins/"+p.Name)
+		writeJSON(w, http.StatusAccepted, p)
+	case errors.Is(err, ErrInvalidPlugin):
+		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, ErrPluginExists):
+		writeError(w, http.StatusConflict, "a plugin with that name is already loaded; use PUT to update it")
+	default:
+		writeError(w, http.StatusBadRequest, err.Error())
+	}
+}
+
+func (s *Server) handleUpdatePlugin(w http.ResponseWriter, r *http.Request) {
+	var req PluginRequest
+	if err := decodeJSON(r, &req, maxPluginBody); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	p, err := s.sup.UpdatePlugin(r.PathValue("name"), req)
+	switch {
+	case err == nil:
+		writeJSON(w, http.StatusAccepted, p)
+	case errors.Is(err, ErrPluginNotFound):
+		writeError(w, http.StatusNotFound, "no such plugin")
+	default:
+		writeError(w, http.StatusBadRequest, err.Error())
+	}
+}
+
+func (s *Server) handleRemovePlugin(w http.ResponseWriter, r *http.Request) {
+	p, err := s.sup.RemovePlugin(r.PathValue("name"))
+	switch {
+	case err == nil:
+		// Removing a plugin edits the manifest — new jobs can no longer
+		// declare it. It does not disturb running pipelines (they hold their
+		// own snapshot), and the built binary stays in the store cache; any
+		// copy already loaded by a job stays resident until restart (Go
+		// plugins cannot be unloaded).
+		writeJSON(w, http.StatusOK, map[string]any{
+			"plugin": p,
+			"note":   "removed from the manifest; running pipelines are unaffected, and the built binary remains in the store cache",
+		})
+	case errors.Is(err, ErrPluginNotFound):
+		writeError(w, http.StatusNotFound, "no such plugin")
+	default:
+		writeError(w, http.StatusInternalServerError, err.Error())
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -21,11 +21,20 @@ const maxDispatchBody = 1 << 20
 type Server struct {
 	sup Supervisor
 	mux *http.ServeMux
+
+	// authUser/authPass gate the plugin routes when set (see auth.go and
+	// WithBasicAuth). Empty means auth is disabled.
+	authUser string
+	authPass string
 }
 
-// New builds a Server backed by sup and wires every route.
-func New(sup Supervisor) *Server {
+// New builds a Server backed by sup, applies any options, and wires every
+// route.
+func New(sup Supervisor, opts ...Option) *Server {
 	s := &Server{sup: sup, mux: http.NewServeMux()}
+	for _, o := range opts {
+		o(s)
+	}
 	s.routes()
 	return s
 }
@@ -51,11 +60,14 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("DELETE /api/v1/pipelines/{id}", s.handleCancelPipeline)
 	s.mux.HandleFunc("GET /api/v1/pipelines/{id}/stats", s.handlePipelineStats)
 
-	s.mux.HandleFunc("GET /api/v1/plugins", s.handleListPlugins)
-	s.mux.HandleFunc("POST /api/v1/plugins", s.handleAddPlugin)
-	s.mux.HandleFunc("GET /api/v1/plugins/{name}", s.handleGetPlugin)
-	s.mux.HandleFunc("PUT /api/v1/plugins/{name}", s.handleUpdatePlugin)
-	s.mux.HandleFunc("DELETE /api/v1/plugins/{name}", s.handleRemovePlugin)
+	// Plugin routes are gated by Basic auth when a credential is configured
+	// (see auth.go). Registration clones + compiles operator-supplied
+	// sources, so the whole subtree is guarded, reads included.
+	s.mux.HandleFunc("GET /api/v1/plugins", s.guard(s.handleListPlugins))
+	s.mux.HandleFunc("POST /api/v1/plugins", s.guard(s.handleAddPlugin))
+	s.mux.HandleFunc("GET /api/v1/plugins/{name}", s.guard(s.handleGetPlugin))
+	s.mux.HandleFunc("PUT /api/v1/plugins/{name}", s.guard(s.handleUpdatePlugin))
+	s.mux.HandleFunc("DELETE /api/v1/plugins/{name}", s.guard(s.handleRemovePlugin))
 
 	// Stage 2 (peer-to-peer) is reserved but not implemented.
 	s.mux.HandleFunc("GET /api/v1/peers", s.handlePeers)

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,189 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// maxDispatchBody caps the size of a dispatch payload we'll read, so a
+// runaway or hostile body can't exhaust memory. A .psy document is small;
+// 1 MiB is generous.
+const maxDispatchBody = 1 << 20
+
+// Server is the HTTP API for one psyduck instance. It is a thin marshaling
+// layer over a Supervisor — construct it with New, then either mount
+// Handler() into your own http.Server or call ListenAndServe.
+type Server struct {
+	sup Supervisor
+	mux *http.ServeMux
+}
+
+// New builds a Server backed by sup and wires every route.
+func New(sup Supervisor) *Server {
+	s := &Server{sup: sup, mux: http.NewServeMux()}
+	s.routes()
+	return s
+}
+
+// Handler exposes the routed mux, for tests (httptest) or for mounting the
+// API under a larger server.
+func (s *Server) Handler() http.Handler { return s.mux }
+
+// routes registers every endpoint. Patterns use net/http's method+wildcard
+// syntax (Go 1.22+): the method is matched, {id} is a path variable read
+// back with r.PathValue("id"). More specific patterns win, so the /stats
+// sub-route coexists with the bare {id} route.
+func (s *Server) routes() {
+	s.mux.HandleFunc("GET /healthz", s.handleHealth)
+	s.mux.HandleFunc("GET /metrics", s.handleMetrics)
+
+	s.mux.HandleFunc("GET /api/v1/instance", s.handleInstance)
+	s.mux.HandleFunc("GET /api/v1/graph", s.handleGraph)
+
+	s.mux.HandleFunc("GET /api/v1/pipelines", s.handleListPipelines)
+	s.mux.HandleFunc("POST /api/v1/pipelines", s.handleDispatch)
+	s.mux.HandleFunc("GET /api/v1/pipelines/{id}", s.handleGetPipeline)
+	s.mux.HandleFunc("DELETE /api/v1/pipelines/{id}", s.handleCancelPipeline)
+	s.mux.HandleFunc("GET /api/v1/pipelines/{id}/stats", s.handlePipelineStats)
+
+	// Stage 2 (peer-to-peer) is reserved but not implemented.
+	s.mux.HandleFunc("GET /api/v1/peers", s.handlePeers)
+}
+
+// ListenAndServe serves the API on addr until ctx is canceled, then shuts
+// down gracefully (draining in-flight requests up to a short grace period).
+// It returns nil on a clean ctx-driven shutdown and the underlying error
+// otherwise.
+func (s *Server) ListenAndServe(ctx context.Context, addr string) error {
+	httpSrv := &http.Server{
+		Addr:              addr,
+		Handler:           s.mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- httpSrv.ListenAndServe() }()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return httpSrv.Shutdown(shutCtx)
+	}
+}
+
+// --- handlers ---------------------------------------------------------------
+
+func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleInstance(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, s.sup.Instance())
+}
+
+func (s *Server) handleListPipelines(w http.ResponseWriter, _ *http.Request) {
+	// Wrap in an object so the top-level response is extensible (paging,
+	// filters) without breaking clients that read a bare array.
+	writeJSON(w, http.StatusOK, map[string]any{"pipelines": s.sup.List()})
+}
+
+func (s *Server) handleGetPipeline(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.sup.Get(r.PathValue("id"))
+	if !ok {
+		writeError(w, http.StatusNotFound, "no such pipeline")
+		return
+	}
+	writeJSON(w, http.StatusOK, p)
+}
+
+func (s *Server) handlePipelineStats(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.sup.Get(r.PathValue("id"))
+	if !ok {
+		writeError(w, http.StatusNotFound, "no such pipeline")
+		return
+	}
+	writeJSON(w, http.StatusOK, p.Stats)
+}
+
+func (s *Server) handleDispatch(w http.ResponseWriter, r *http.Request) {
+	var req DispatchRequest
+	if err := decodeJSON(r, &req, maxDispatchBody); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	p, err := s.sup.Dispatch(req)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrInvalidSource):
+			writeError(w, http.StatusBadRequest, "source is required")
+		default:
+			writeError(w, http.StatusBadRequest, err.Error())
+		}
+		return
+	}
+	// 202: accepted, will run asynchronously. Location points at the record.
+	w.Header().Set("Location", "/api/v1/pipelines/"+p.ID)
+	writeJSON(w, http.StatusAccepted, p)
+}
+
+func (s *Server) handleCancelPipeline(w http.ResponseWriter, r *http.Request) {
+	err := s.sup.Cancel(r.PathValue("id"))
+	switch {
+	case err == nil:
+		p, _ := s.sup.Get(r.PathValue("id"))
+		writeJSON(w, http.StatusOK, p)
+	case errors.Is(err, ErrNotFound):
+		writeError(w, http.StatusNotFound, "no such pipeline")
+	case errors.Is(err, ErrNotCancelable):
+		writeError(w, http.StatusConflict, "pipeline already finished")
+	default:
+		writeError(w, http.StatusInternalServerError, err.Error())
+	}
+}
+
+func (s *Server) handleGraph(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, s.sup.Graph())
+}
+
+// handlePeers is the reserved stage-2 surface. It answers 501 with a note so
+// a client can discover that peers are planned but unavailable, rather than
+// 404 (which would read as "no such route").
+func (s *Server) handlePeers(w http.ResponseWriter, _ *http.Request) {
+	writeError(w, http.StatusNotImplemented, "peer-to-peer is not implemented yet (stage 2); see docs/http-api.md")
+}
+
+// --- json helpers -----------------------------------------------------------
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	_ = enc.Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// decodeJSON reads a JSON body into v, bounded by limit bytes and rejecting
+// unknown fields so a typo in a dispatch payload is an error, not a silent
+// no-op.
+func decodeJSON(r *http.Request, v any, limit int64) error {
+	dec := json.NewDecoder(io.LimitReader(r.Body, limit))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -51,6 +51,12 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("DELETE /api/v1/pipelines/{id}", s.handleCancelPipeline)
 	s.mux.HandleFunc("GET /api/v1/pipelines/{id}/stats", s.handlePipelineStats)
 
+	s.mux.HandleFunc("GET /api/v1/plugins", s.handleListPlugins)
+	s.mux.HandleFunc("POST /api/v1/plugins", s.handleAddPlugin)
+	s.mux.HandleFunc("GET /api/v1/plugins/{name}", s.handleGetPlugin)
+	s.mux.HandleFunc("PUT /api/v1/plugins/{name}", s.handleUpdatePlugin)
+	s.mux.HandleFunc("DELETE /api/v1/plugins/{name}", s.handleRemovePlugin)
+
 	// Stage 2 (peer-to-peer) is reserved but not implemented.
 	s.mux.HandleFunc("GET /api/v1/peers", s.handlePeers)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -209,3 +209,73 @@ func TestPeersNotImplemented(t *testing.T) {
 		t.Fatalf("peers: got %d, want 501", w.Code)
 	}
 }
+
+func TestPluginLifecycleOverHTTP(t *testing.T) {
+	srv := newTestServer()
+
+	// Empty to start.
+	w := do(t, srv, http.MethodGet, "/api/v1/plugins", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: got %d", w.Code)
+	}
+
+	// Add (202).
+	body, _ := json.Marshal(PluginRequest{Name: "amqp", Source: "https://github.com/psyduck-etl/amqp", Tag: "v0.1.0"})
+	wa := do(t, srv, http.MethodPost, "/api/v1/plugins", body)
+	if wa.Code != http.StatusAccepted {
+		t.Fatalf("add: got %d, want 202", wa.Code)
+	}
+	if loc := wa.Header().Get("Location"); loc != "/api/v1/plugins/amqp" {
+		t.Errorf("location: %q", loc)
+	}
+
+	// Duplicate add is a conflict.
+	wd := do(t, srv, http.MethodPost, "/api/v1/plugins", body)
+	if wd.Code != http.StatusConflict {
+		t.Errorf("duplicate add: got %d, want 409", wd.Code)
+	}
+
+	// Manifest.
+	wm := do(t, srv, http.MethodGet, "/api/v1/plugins/amqp", nil)
+	if wm.Code != http.StatusOK {
+		t.Fatalf("manifest: got %d", wm.Code)
+	}
+	var man PluginManifest
+	if err := json.Unmarshal(wm.Body.Bytes(), &man); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if man.Name != "amqp" || len(man.Resources) == 0 {
+		t.Errorf("manifest: %+v", man)
+	}
+
+	// Update (202).
+	upd, _ := json.Marshal(PluginRequest{Source: "https://github.com/psyduck-etl/amqp", Tag: "v0.2.0"})
+	wu := do(t, srv, http.MethodPut, "/api/v1/plugins/amqp", upd)
+	if wu.Code != http.StatusAccepted {
+		t.Errorf("update: got %d, want 202", wu.Code)
+	}
+
+	// Delete.
+	wdel := do(t, srv, http.MethodDelete, "/api/v1/plugins/amqp", nil)
+	if wdel.Code != http.StatusOK {
+		t.Errorf("delete: got %d, want 200", wdel.Code)
+	}
+	// Gone now.
+	if w := do(t, srv, http.MethodGet, "/api/v1/plugins/amqp", nil); w.Code != http.StatusNotFound {
+		t.Errorf("get after delete: got %d, want 404", w.Code)
+	}
+}
+
+func TestAddPluginRejectsMissingSource(t *testing.T) {
+	w := do(t, newTestServer(), http.MethodPost, "/api/v1/plugins", []byte(`{"name":"x"}`))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("missing source: got %d, want 400", w.Code)
+	}
+}
+
+func TestUpdateUnknownPlugin(t *testing.T) {
+	w := do(t, newTestServer(), http.MethodPut, "/api/v1/plugins/nope", []byte(`{"source":"x"}`))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("update unknown: got %d, want 404", w.Code)
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,211 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedClock returns a deterministic time so uptime/timestamps are testable.
+func fixedClock() func() time.Time {
+	t := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	return func() time.Time { return t }
+}
+
+func newTestServer() *Server {
+	return New(newStubSupervisor(fixedClock()))
+}
+
+func do(t *testing.T, srv *Server, method, path string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body != nil {
+		r = httptest.NewRequest(method, path, bytes.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, path, nil)
+	}
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, r)
+	return w
+}
+
+func TestHealth(t *testing.T) {
+	w := do(t, newTestServer(), http.MethodGet, "/healthz", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("health: got %d, want 200", w.Code)
+	}
+}
+
+func TestInstance(t *testing.T) {
+	w := do(t, newTestServer(), http.MethodGet, "/api/v1/instance", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("instance: got %d, want 200", w.Code)
+	}
+	var got InstanceInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Version != Version {
+		t.Errorf("version: got %q, want %q", got.Version, Version)
+	}
+	// Seeded with one running + one succeeded pipeline.
+	if got.Pipelines.Total != 2 || got.Pipelines.Running != 1 || got.Pipelines.Succeeded != 1 {
+		t.Errorf("counts: %+v", got.Pipelines)
+	}
+}
+
+func TestListPipelines(t *testing.T) {
+	w := do(t, newTestServer(), http.MethodGet, "/api/v1/pipelines", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: got %d, want 200", w.Code)
+	}
+	var got struct {
+		Pipelines []PipelineInfo `json:"pipelines"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Pipelines) != 2 {
+		t.Fatalf("pipelines: got %d, want 2", len(got.Pipelines))
+	}
+}
+
+func TestGetPipelineAndStats(t *testing.T) {
+	srv := newTestServer()
+	// pipe-000001 is the seeded running pipeline.
+	w := do(t, srv, http.MethodGet, "/api/v1/pipelines/pipe-000001", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get: got %d, want 200", w.Code)
+	}
+	var p PipelineInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &p); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if p.Name != "ingest" || p.Status != StatusRunning {
+		t.Errorf("pipeline: got name=%q status=%q", p.Name, p.Status)
+	}
+
+	ws := do(t, srv, http.MethodGet, "/api/v1/pipelines/pipe-000001/stats", nil)
+	if ws.Code != http.StatusOK {
+		t.Fatalf("stats: got %d, want 200", ws.Code)
+	}
+	var st Stats
+	if err := json.Unmarshal(ws.Body.Bytes(), &st); err != nil {
+		t.Fatalf("decode stats: %v", err)
+	}
+	if st.Produced == 0 {
+		t.Errorf("stats: expected non-zero produced, got %+v", st)
+	}
+}
+
+func TestGetPipelineNotFound(t *testing.T) {
+	w := do(t, newTestServer(), http.MethodGet, "/api/v1/pipelines/nope", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("missing: got %d, want 404", w.Code)
+	}
+}
+
+func TestDispatchLifecycle(t *testing.T) {
+	srv := newTestServer()
+
+	body, _ := json.Marshal(DispatchRequest{
+		Name:   "adhoc",
+		Source: `pipeline "adhoc" {}`,
+		Labels: map[string]string{"who": "test"},
+	})
+	w := do(t, srv, http.MethodPost, "/api/v1/pipelines", body)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("dispatch: got %d, want 202", w.Code)
+	}
+	if loc := w.Header().Get("Location"); !strings.HasPrefix(loc, "/api/v1/pipelines/") {
+		t.Errorf("location header: %q", loc)
+	}
+	var created PipelineInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if created.Status != StatusPending {
+		t.Errorf("dispatched status: got %q, want pending", created.Status)
+	}
+
+	// Now cancel it.
+	wc := do(t, srv, http.MethodDelete, "/api/v1/pipelines/"+created.ID, nil)
+	if wc.Code != http.StatusOK {
+		t.Fatalf("cancel: got %d, want 200", wc.Code)
+	}
+	var canceled PipelineInfo
+	if err := json.Unmarshal(wc.Body.Bytes(), &canceled); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if canceled.Status != StatusCanceled {
+		t.Errorf("canceled status: got %q", canceled.Status)
+	}
+
+	// Canceling again is a conflict (already terminal).
+	wc2 := do(t, srv, http.MethodDelete, "/api/v1/pipelines/"+created.ID, nil)
+	if wc2.Code != http.StatusConflict {
+		t.Errorf("re-cancel: got %d, want 409", wc2.Code)
+	}
+}
+
+func TestDispatchRejectsEmptySource(t *testing.T) {
+	srv := newTestServer()
+	body, _ := json.Marshal(DispatchRequest{Name: "x"})
+	w := do(t, srv, http.MethodPost, "/api/v1/pipelines", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("empty source: got %d, want 400", w.Code)
+	}
+}
+
+func TestDispatchRejectsUnknownField(t *testing.T) {
+	srv := newTestServer()
+	w := do(t, srv, http.MethodPost, "/api/v1/pipelines", []byte(`{"nope": 1}`))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("unknown field: got %d, want 400", w.Code)
+	}
+}
+
+func TestGraph(t *testing.T) {
+	w := do(t, newTestServer(), http.MethodGet, "/api/v1/graph", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("graph: got %d, want 200", w.Code)
+	}
+	var g Graph
+	if err := json.Unmarshal(w.Body.Bytes(), &g); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Two pipeline nodes plus their stage nodes; edges wire the chains.
+	if len(g.Nodes) == 0 || len(g.Edges) == 0 {
+		t.Errorf("graph: nodes=%d edges=%d, want both non-empty", len(g.Nodes), len(g.Edges))
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	w := do(t, newTestServer(), http.MethodGet, "/metrics", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("metrics: got %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"# TYPE psyduck_pipelines gauge",
+		"psyduck_pipelines{status=\"running\"} 1",
+		"# TYPE psyduck_pipeline_messages_produced_total counter",
+		"psyduck_pipeline_messages_produced_total{pipeline=\"pipe-000001\",name=\"ingest\"} 1280",
+		"psyduck_instance_uptime_seconds",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("metrics missing %q\n---\n%s", want, body)
+		}
+	}
+}
+
+func TestPeersNotImplemented(t *testing.T) {
+	w := do(t, newTestServer(), http.MethodGet, "/api/v1/peers", nil)
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("peers: got %d, want 501", w.Code)
+	}
+}

--- a/server/supervisor.go
+++ b/server/supervisor.go
@@ -1,0 +1,284 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Supervisor is everything the HTTP layer needs from the pipeline runtime.
+// It owns the pipelines this instance is running and answers questions about
+// them; the server package only ever talks to this interface, never to core
+// or parse. That keeps the API testable against a stub and lets the live,
+// pipeline-owning implementation land later without touching any handler.
+//
+// Every method must be safe for concurrent use — the HTTP server calls them
+// from many goroutines.
+type Supervisor interface {
+	// Instance returns this instance's identity and rolled-up pipeline
+	// counts.
+	Instance() InstanceInfo
+
+	// List returns every pipeline this instance knows about — running,
+	// pending, and recently terminal — in a stable order.
+	List() []PipelineInfo
+
+	// Get returns one pipeline by id. The bool is false if no such pipeline
+	// exists.
+	Get(id string) (PipelineInfo, bool)
+
+	// Dispatch accepts a pipeline to run and returns its freshly-created
+	// record (status pending). It validates the request but does not block
+	// on the pipeline actually starting.
+	Dispatch(req DispatchRequest) (PipelineInfo, error)
+
+	// Cancel stops a running or pending pipeline. It returns ErrNotFound if
+	// the id is unknown and ErrNotCancelable if the pipeline has already
+	// reached a terminal state.
+	Cancel(id string) error
+
+	// Graph returns the node/edge projection of everything running, for a
+	// visualization board.
+	Graph() Graph
+}
+
+// Supervisor error sentinels. Handlers map these onto HTTP status codes.
+var (
+	ErrNotFound      = errors.New("pipeline not found")
+	ErrNotCancelable = errors.New("pipeline is not cancelable")
+	ErrInvalidSource = errors.New("dispatch source is empty")
+)
+
+// StubSupervisor is an in-memory Supervisor that keeps the API coherent
+// without a running pipeline behind it: it seeds a couple of representative
+// pipelines, accepts Dispatch (recording a pending pipeline but running
+// nothing), and honors Cancel. It exists so the HTTP surface is real and
+// exercisable — by tests, by a UI being built against it, by curl — before
+// the runtime grows a real supervisor. Every value it returns has the exact
+// shape the live implementation will.
+//
+// What it deliberately does NOT do: parse Source, build a core.Pipeline,
+// run anything, or move counters on its own. Those are the "wiring it live"
+// follow-ups in docs/http-api.md.
+type StubSupervisor struct {
+	id        string
+	startedAt time.Time
+
+	mu    sync.Mutex
+	seq   atomic.Uint64
+	byID  map[string]*PipelineInfo
+	order []string // insertion order, for stable listing
+	nowFn func() time.Time
+}
+
+var _ Supervisor = (*StubSupervisor)(nil)
+
+// NewStubSupervisor builds a stub seeded with a small, representative set of
+// pipelines so the endpoints return something recognizable out of the box.
+func NewStubSupervisor() *StubSupervisor {
+	return newStubSupervisor(time.Now)
+}
+
+// newStubSupervisor is the injectable-clock constructor tests use for
+// deterministic timestamps.
+func newStubSupervisor(now func() time.Time) *StubSupervisor {
+	s := &StubSupervisor{
+		id:        "psyduck-local",
+		startedAt: now(),
+		byID:      make(map[string]*PipelineInfo),
+		nowFn:     now,
+	}
+	s.seed()
+	return s
+}
+
+// nextID hands out stable, sortable ids without needing a random source.
+func (s *StubSupervisor) nextID() string {
+	return fmt.Sprintf("pipe-%06d", s.seq.Add(1))
+}
+
+// seed installs two demo pipelines: one running with live-looking counters,
+// one already succeeded. They give every read endpoint non-trivial data.
+func (s *StubSupervisor) seed() {
+	start := s.startedAt
+	running := &PipelineInfo{
+		ID:     s.nextID(),
+		Name:   "ingest",
+		Status: StatusRunning,
+		Source: "file:examples/ingest.psy",
+		Topology: Topology{
+			Producers:    []ResourceRef{{Ref: "produce.http-listen.hook", Kind: StageProduce}},
+			Transformers: []ResourceRef{{Ref: "transform.jq.shape", Kind: StageTransform}, {Ref: "transform.set.tag", Kind: StageTransform}},
+			Consumers:    []ResourceRef{{Ref: "consume.socket.bus", Kind: StageConsume}},
+		},
+		Stats:     Stats{Produced: 1280, Transformed: 1204, Filtered: 76, Delivered: 1204, Errors: 2, InFlight: 0},
+		CreatedAt: start,
+		StartedAt: &start,
+	}
+	fin := start.Add(90 * time.Second)
+	done := &PipelineInfo{
+		ID:     s.nextID(),
+		Name:   "backfill",
+		Status: StatusSucceeded,
+		Source: "dispatch:nightly-backfill",
+		Labels: map[string]string{"run": "nightly"},
+		Topology: Topology{
+			RemoteSeed:   &ResourceRef{Ref: "produce.listen.jobs", Kind: StageProduce},
+			Transformers: []ResourceRef{{Ref: "transform.pick-map.core", Kind: StageTransform}},
+			Consumers:    []ResourceRef{{Ref: "consume.file.results", Kind: StageConsume}},
+		},
+		Stats:      Stats{Produced: 5000, Transformed: 5000, Filtered: 0, Delivered: 5000, Errors: 0, InFlight: 0},
+		CreatedAt:  start,
+		StartedAt:  &start,
+		FinishedAt: &fin,
+	}
+	s.byID[running.ID] = running
+	s.byID[done.ID] = done
+	s.order = append(s.order, running.ID, done.ID)
+}
+
+func (s *StubSupervisor) Instance() InstanceInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return InstanceInfo{
+		ID:            s.id,
+		Version:       Version,
+		StartedAt:     s.startedAt,
+		UptimeSeconds: s.nowFn().Sub(s.startedAt).Seconds(),
+		Pipelines:     s.countsLocked(),
+	}
+}
+
+// countsLocked tallies pipelines by status. Caller holds s.mu.
+func (s *StubSupervisor) countsLocked() PipelineCounts {
+	var c PipelineCounts
+	for _, id := range s.order {
+		c.Total++
+		switch s.byID[id].Status {
+		case StatusRunning:
+			c.Running++
+		case StatusPending:
+			c.Pending++
+		case StatusSucceeded:
+			c.Succeeded++
+		case StatusFailed:
+			c.Failed++
+		case StatusCanceled:
+			c.Canceled++
+		}
+	}
+	return c
+}
+
+func (s *StubSupervisor) List() []PipelineInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]PipelineInfo, 0, len(s.order))
+	for _, id := range s.order {
+		out = append(out, *s.byID[id])
+	}
+	return out
+}
+
+func (s *StubSupervisor) Get(id string) (PipelineInfo, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.byID[id]
+	if !ok {
+		return PipelineInfo{}, false
+	}
+	return *p, true
+}
+
+func (s *StubSupervisor) Dispatch(req DispatchRequest) (PipelineInfo, error) {
+	if req.Source == "" {
+		return PipelineInfo{}, ErrInvalidSource
+	}
+	name := req.Name
+	if name == "" {
+		name = "dispatched"
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.nowFn()
+	p := &PipelineInfo{
+		ID:        s.nextID(),
+		Name:      name,
+		Status:    StatusPending,
+		Source:    "dispatch:" + name,
+		Labels:    req.Labels,
+		CreatedAt: now,
+		// Topology and Stats stay zero until a real supervisor parses
+		// Source and starts the run.
+	}
+	s.byID[p.ID] = p
+	s.order = append(s.order, p.ID)
+	return *p, nil
+}
+
+func (s *StubSupervisor) Cancel(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.byID[id]
+	if !ok {
+		return ErrNotFound
+	}
+	if p.Status != StatusRunning && p.Status != StatusPending {
+		return ErrNotCancelable
+	}
+	p.Status = StatusCanceled
+	fin := s.nowFn()
+	p.FinishedAt = &fin
+	return nil
+}
+
+func (s *StubSupervisor) Graph() Graph {
+	return buildGraph(s.List())
+}
+
+// buildGraph projects a set of pipelines into nodes and edges. It is pure
+// (no supervisor state), so the live supervisor can reuse it verbatim. Each
+// pipeline becomes a container node; each of its stages becomes a node wired
+// in declaration order producer(s) → transform(s) → consumer(s). A
+// produce-from seed is rendered as the single head node.
+func buildGraph(pipelines []PipelineInfo) Graph {
+	g := Graph{Nodes: []GraphNode{}, Edges: []GraphEdge{}}
+	for _, p := range pipelines {
+		stats := p.Stats
+		g.Nodes = append(g.Nodes, GraphNode{
+			ID:     p.ID,
+			Kind:   "pipeline",
+			Label:  p.Name,
+			Status: string(p.Status),
+			Stats:  &stats,
+		})
+
+		// Flatten the pipeline's stages into an ordered chain of node ids.
+		var chain []string
+		add := func(refs []ResourceRef) {
+			for i, r := range refs {
+				nid := fmt.Sprintf("%s:%s:%d", p.ID, r.Kind, i)
+				g.Nodes = append(g.Nodes, GraphNode{ID: nid, Kind: string(r.Kind), Label: r.Ref, Pipeline: p.ID})
+				chain = append(chain, nid)
+			}
+		}
+		if p.Topology.RemoteSeed != nil {
+			add([]ResourceRef{*p.Topology.RemoteSeed})
+		} else {
+			add(p.Topology.Producers)
+		}
+		add(p.Topology.Transformers)
+		add(p.Topology.Consumers)
+
+		for i := 0; i+1 < len(chain); i++ {
+			g.Edges = append(g.Edges, GraphEdge{From: chain[i], To: chain[i+1], Messages: p.Stats.Delivered})
+		}
+	}
+	// Stable node order regardless of map iteration in the source.
+	sort.SliceStable(g.Nodes, func(i, j int) bool { return g.Nodes[i].ID < g.Nodes[j].ID })
+	return g
+}

--- a/server/supervisor.go
+++ b/server/supervisor.go
@@ -43,6 +43,32 @@ type Supervisor interface {
 	// Graph returns the node/edge projection of everything running, for a
 	// visualization board.
 	Graph() Graph
+
+	// Plugins lists every plugin the instance has been asked to load, with
+	// its status. Loading is asynchronous (clone + compile), so a plugin may
+	// be loading or failed as well as ready.
+	Plugins() []PluginInfo
+
+	// Plugin returns one plugin's full manifest — its resources and their
+	// config options. The bool is false if no such plugin exists.
+	Plugin(name string) (PluginManifest, bool)
+
+	// AddPlugin loads a new plugin from a plugin{}-style spec (a partial,
+	// on-demand `init`). It returns the freshly-created record (status
+	// loading) and does not block on the build. ErrPluginExists if the name
+	// is already loaded; ErrInvalidPlugin if name/source are missing.
+	AddPlugin(req PluginRequest) (PluginInfo, error)
+
+	// UpdatePlugin re-fetches an existing plugin at a new source/tag.
+	// ErrPluginNotFound if the name is unknown. Because a resident Go plugin
+	// cannot be reloaded in-process, updating one that is already loaded
+	// rebuilds the binary and sets RestartRequired rather than hot-swapping.
+	UpdatePlugin(name string, req PluginRequest) (PluginInfo, error)
+
+	// RemovePlugin deregisters a plugin so new dispatches no longer see it.
+	// ErrPluginNotFound if the name is unknown. The compiled binary stays
+	// resident until the process restarts (Go plugins cannot be unloaded).
+	RemovePlugin(name string) (PluginInfo, error)
 }
 
 // Supervisor error sentinels. Handlers map these onto HTTP status codes.
@@ -72,6 +98,10 @@ type StubSupervisor struct {
 	byID  map[string]*PipelineInfo
 	order []string // insertion order, for stable listing
 	nowFn func() time.Time
+
+	pmu       sync.Mutex
+	plugins   map[string]*PluginInfo
+	pluginOrd []string
 }
 
 var _ Supervisor = (*StubSupervisor)(nil)
@@ -90,6 +120,7 @@ func newStubSupervisor(now func() time.Time) *StubSupervisor {
 		startedAt: now(),
 		byID:      make(map[string]*PipelineInfo),
 		nowFn:     now,
+		plugins:   make(map[string]*PluginInfo),
 	}
 	s.seed()
 	return s
@@ -238,6 +269,93 @@ func (s *StubSupervisor) Cancel(id string) error {
 
 func (s *StubSupervisor) Graph() Graph {
 	return BuildGraph(s.List())
+}
+
+// The plugin methods below keep the stub self-consistent so the server
+// package can test the routes: AddPlugin records a plugin as immediately
+// "ready" with a canned one-resource manifest (no clone/build), and the
+// rest read/mutate that in-memory registry. A live instance does the real
+// clone/compile/load (see the supervise package).
+
+func (s *StubSupervisor) Plugins() []PluginInfo {
+	s.pmu.Lock()
+	defer s.pmu.Unlock()
+	out := make([]PluginInfo, 0, len(s.pluginOrd))
+	for _, name := range s.pluginOrd {
+		out = append(out, *s.plugins[name])
+	}
+	return out
+}
+
+func (s *StubSupervisor) Plugin(name string) (PluginManifest, bool) {
+	s.pmu.Lock()
+	defer s.pmu.Unlock()
+	p, ok := s.plugins[name]
+	if !ok {
+		return PluginManifest{}, false
+	}
+	return PluginManifest{
+		Name:   p.Name,
+		Source: p.Source,
+		Ref:    p.Ref,
+		Status: p.Status,
+		Resources: []PluginResource{{
+			Name:    "example",
+			Kinds:   []string{"produce"},
+			Options: []PluginOption{{Name: "value", Type: "string", Description: "stubbed option"}},
+		}},
+	}, true
+}
+
+func (s *StubSupervisor) AddPlugin(req PluginRequest) (PluginInfo, error) {
+	if req.Name == "" || req.Source == "" {
+		return PluginInfo{}, ErrInvalidPlugin
+	}
+	s.pmu.Lock()
+	defer s.pmu.Unlock()
+	if _, ok := s.plugins[req.Name]; ok {
+		return PluginInfo{}, ErrPluginExists
+	}
+	now := s.nowFn()
+	p := &PluginInfo{
+		Name: req.Name, Source: req.Source, Tag: req.Tag,
+		Status: PluginReady, Resources: 1, AddedAt: now, LoadedAt: &now,
+	}
+	s.plugins[req.Name] = p
+	s.pluginOrd = append(s.pluginOrd, req.Name)
+	return *p, nil
+}
+
+func (s *StubSupervisor) UpdatePlugin(name string, req PluginRequest) (PluginInfo, error) {
+	s.pmu.Lock()
+	defer s.pmu.Unlock()
+	p, ok := s.plugins[name]
+	if !ok {
+		return PluginInfo{}, ErrPluginNotFound
+	}
+	if req.Source != "" {
+		p.Source = req.Source
+	}
+	p.Tag = req.Tag
+	p.RestartRequired = true
+	return *p, nil
+}
+
+func (s *StubSupervisor) RemovePlugin(name string) (PluginInfo, error) {
+	s.pmu.Lock()
+	defer s.pmu.Unlock()
+	p, ok := s.plugins[name]
+	if !ok {
+		return PluginInfo{}, ErrPluginNotFound
+	}
+	delete(s.plugins, name)
+	for i, n := range s.pluginOrd {
+		if n == name {
+			s.pluginOrd = append(s.pluginOrd[:i], s.pluginOrd[i+1:]...)
+			break
+		}
+	}
+	return *p, nil
 }
 
 // BuildGraph projects a set of pipelines into nodes and edges. It is pure

--- a/server/supervisor.go
+++ b/server/supervisor.go
@@ -237,15 +237,15 @@ func (s *StubSupervisor) Cancel(id string) error {
 }
 
 func (s *StubSupervisor) Graph() Graph {
-	return buildGraph(s.List())
+	return BuildGraph(s.List())
 }
 
-// buildGraph projects a set of pipelines into nodes and edges. It is pure
+// BuildGraph projects a set of pipelines into nodes and edges. It is pure
 // (no supervisor state), so the live supervisor can reuse it verbatim. Each
 // pipeline becomes a container node; each of its stages becomes a node wired
 // in declaration order producer(s) → transform(s) → consumer(s). A
 // produce-from seed is rendered as the single head node.
-func buildGraph(pipelines []PipelineInfo) Graph {
+func BuildGraph(pipelines []PipelineInfo) Graph {
 	g := Graph{Nodes: []GraphNode{}, Edges: []GraphEdge{}}
 	for _, p := range pipelines {
 		stats := p.Stats

--- a/server/types.go
+++ b/server/types.go
@@ -1,0 +1,157 @@
+package server
+
+import "time"
+
+// PipelineStatus is the lifecycle state of a pipeline known to this
+// instance. A dispatched pipeline starts pending, becomes running once the
+// supervisor has built and started it, and lands in exactly one terminal
+// state.
+type PipelineStatus string
+
+const (
+	StatusPending   PipelineStatus = "pending"   // accepted, not yet started
+	StatusRunning   PipelineStatus = "running"   // producing/consuming right now
+	StatusSucceeded PipelineStatus = "succeeded" // producers exhausted, consumers flushed
+	StatusFailed    PipelineStatus = "failed"    // stopped by an error (see PipelineInfo.Error)
+	StatusCanceled  PipelineStatus = "canceled"  // stopped by a caller (DELETE) or shutdown
+)
+
+// StageKind names which of the three pipeline slots a resource fills. It
+// mirrors sdk.Kind's producer/transformer/consumer split, as a string the
+// API can hand to a UI.
+type StageKind string
+
+const (
+	StageProduce   StageKind = "produce"
+	StageTransform StageKind = "transform"
+	StageConsume   StageKind = "consume"
+)
+
+// ResourceRef is one resource in a pipeline's topology, named by its
+// qualified reference (e.g. "produce.request.api"). It is display metadata
+// only — the API never exposes evaluated config, which can hold secrets.
+type ResourceRef struct {
+	Ref  string    `json:"ref"`
+	Kind StageKind `json:"kind"`
+}
+
+// Topology is a pipeline's declared shape: the resources in each slot, in
+// declaration order. RemoteSeed is set instead of Producers when the
+// pipeline uses produce-from (a dynamic/meta producer) — see
+// parse.PipelineSpec, which this mirrors.
+type Topology struct {
+	Producers    []ResourceRef `json:"producers"`
+	Transformers []ResourceRef `json:"transformers"`
+	Consumers    []ResourceRef `json:"consumers"`
+	RemoteSeed   *ResourceRef  `json:"remote_seed,omitempty"`
+}
+
+// Stats is a point-in-time counter snapshot for one pipeline. The counters
+// map onto the observable events in core.RunPipeline's loop: a message is
+// produced, then either filtered by a transformer (nil result today),
+// delivered to consumers, or turns into an error. InFlight is a coarse lag
+// gauge — produced minus everything that has since left the pipeline.
+//
+// Counters are monotonic within a single run; a UI computes rates by
+// diffing snapshots over time.
+type Stats struct {
+	Produced    uint64 `json:"produced"`
+	Transformed uint64 `json:"transformed"`
+	Filtered    uint64 `json:"filtered"`
+	Delivered   uint64 `json:"delivered"`
+	Errors      uint64 `json:"errors"`
+	InFlight    int64  `json:"in_flight"`
+}
+
+// PipelineInfo is the full API view of one pipeline. It is what
+// GET /api/v1/pipelines/{id} returns and what the list endpoint returns per
+// entry.
+type PipelineInfo struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Status     PipelineStatus    `json:"status"`
+	Source     string            `json:"source"` // "file:<path>" or "dispatch:<label>"
+	Labels     map[string]string `json:"labels,omitempty"`
+	Topology   Topology          `json:"topology"`
+	Stats      Stats             `json:"stats"`
+	Error      string            `json:"error,omitempty"` // set iff Status == failed
+	CreatedAt  time.Time         `json:"created_at"`
+	StartedAt  *time.Time        `json:"started_at,omitempty"`
+	FinishedAt *time.Time        `json:"finished_at,omitempty"`
+}
+
+// PipelineCounts is the by-status breakdown reported on the instance
+// summary, so a caller can render "3 running, 1 failed" without listing.
+type PipelineCounts struct {
+	Running   int `json:"running"`
+	Pending   int `json:"pending"`
+	Succeeded int `json:"succeeded"`
+	Failed    int `json:"failed"`
+	Canceled  int `json:"canceled"`
+	Total     int `json:"total"`
+}
+
+// InstanceInfo describes this instance to a caller (or a peer, later). It's
+// what GET /api/v1/instance returns and the identity a sibling would learn
+// in stage 2.
+type InstanceInfo struct {
+	ID            string         `json:"id"`
+	Version       string         `json:"version"`
+	StartedAt     time.Time      `json:"started_at"`
+	UptimeSeconds float64        `json:"uptime_seconds"`
+	Pipelines     PipelineCounts `json:"pipelines"`
+}
+
+// DispatchRequest is the body of POST /api/v1/pipelines: a pipeline to run
+// on this instance. Source is a complete .psy document (HCL) — the same
+// text a `psyduck run` file holds — which the supervisor parses, builds,
+// and runs. This is the HTTP front door to the meta-pipeline/remote-worker
+// pattern documented in docs/patterns.md ("Meta-pipelines"): instead of a
+// socket or queue feeding produce-from, an operator (or a peer) POSTs work.
+//
+// Name and Labels are advisory metadata for listing/filtering; if Name is
+// empty the supervisor derives it from the pipeline{} block(s) in Source.
+type DispatchRequest struct {
+	Name   string            `json:"name,omitempty"`
+	Source string            `json:"source"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// Graph is the graph-board view of everything this instance is running:
+// each pipeline and its stages as nodes, wired producer→transform→consumer
+// as edges, with live counters on both. It's a denormalized projection of
+// the same data the pipeline endpoints return, shaped for a node/edge
+// visualization rather than for polling one pipeline.
+type Graph struct {
+	Nodes []GraphNode `json:"nodes"`
+	Edges []GraphEdge `json:"edges"`
+}
+
+// GraphNode is one vertex: either a pipeline container or a single stage
+// within it. Kind is "pipeline" or one of the StageKind values.
+type GraphNode struct {
+	ID       string `json:"id"`
+	Kind     string `json:"kind"`
+	Label    string `json:"label"`
+	Pipeline string `json:"pipeline,omitempty"` // owning pipeline id, for stage nodes
+	Status   string `json:"status,omitempty"`   // for pipeline nodes
+	Stats    *Stats `json:"stats,omitempty"`    // for pipeline nodes
+}
+
+// GraphEdge is a directed link between two GraphNodes. Messages, when known,
+// is the count that has crossed it — enough to weight/animate the edge.
+type GraphEdge struct {
+	From     string `json:"from"`
+	To       string `json:"to"`
+	Messages uint64 `json:"messages,omitempty"`
+}
+
+// Peer is a sibling instance this one has learned about. RESERVED FOR
+// STAGE 2 — it is defined here so the peer-to-peer shape is visible while
+// that design is settled, but nothing populates it yet and the /api/v1/peers
+// route returns 501. See docs/http-api.md, "Stage 2: peers".
+type Peer struct {
+	ID       string    `json:"id"`
+	Address  string    `json:"address"`
+	LastSeen time.Time `json:"last_seen"`
+}

--- a/supervise/plugins.go
+++ b/supervise/plugins.go
@@ -1,0 +1,325 @@
+package supervise
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/psyduck-etl/sdk"
+
+	"github.com/gastrodon/psyduck/parse"
+	"github.com/gastrodon/psyduck/server"
+)
+
+// pluginEntry is one plugin in this instance's manifest: a name bound to a
+// source, and — once built — the git ref and content hash of the .so sitting
+// in the store. "ready" means the binary is built and content-addressed into
+// the store, available for a job to load; it does NOT mean the plugin is
+// resident in this process. Managing plugins is a store/manifest file op;
+// loading is deferred to the jobs that declare them.
+type pluginEntry struct {
+	name    string
+	addedAt time.Time
+
+	mu              sync.Mutex
+	source          string
+	tag             string
+	ref             string
+	hash            string
+	resources       int // known resource count, filled the first time it's introspected
+	status          server.PluginStatus
+	errMsg          string
+	builtAt         *time.Time
+	restartRequired bool
+}
+
+func (e *pluginEntry) info() server.PluginInfo {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return server.PluginInfo{
+		Name:            e.name,
+		Source:          e.source,
+		Tag:             e.tag,
+		Ref:             e.ref,
+		Hash:            e.hash,
+		Status:          e.status,
+		Error:           e.errMsg,
+		Resources:       e.resources,
+		RestartRequired: e.restartRequired,
+		AddedAt:         e.addedAt,
+		LoadedAt:        e.builtAt,
+	}
+}
+
+func (s *Supervisor) Plugins() []server.PluginInfo {
+	s.pmu.Lock()
+	es := make([]*pluginEntry, 0, len(s.pOrder))
+	for _, name := range s.pOrder {
+		es = append(es, s.pByName[name])
+	}
+	s.pmu.Unlock()
+
+	out := make([]server.PluginInfo, 0, len(es))
+	for _, e := range es {
+		out = append(out, e.info())
+	}
+	return out
+}
+
+// Plugin returns a plugin's manifest. Reading the resource list means
+// opening the .so (Resources() is only knowable from the loaded plugin), so
+// this endpoint is what first makes a plugin resident; the opened handle is
+// cached, and the resource count is remembered on the entry.
+func (s *Supervisor) Plugin(name string) (server.PluginManifest, bool) {
+	s.pmu.Lock()
+	e, ok := s.pByName[name]
+	s.pmu.Unlock()
+	if !ok {
+		return server.PluginManifest{}, false
+	}
+
+	e.mu.Lock()
+	man := server.PluginManifest{Name: e.name, Source: e.source, Ref: e.ref, Status: e.status}
+	source, ref, hash, ready := e.source, e.ref, e.hash, e.status == server.PluginReady
+	e.mu.Unlock()
+	if !ready {
+		return man, true // nothing built to introspect yet
+	}
+
+	p, err := s.openCached(name, source, ref, hash)
+	if err != nil {
+		man.Status = server.PluginFailed
+		return man, true
+	}
+	man.Resources = manifestResources(p)
+
+	e.mu.Lock()
+	e.resources = len(man.Resources)
+	e.mu.Unlock()
+	return man, true
+}
+
+// AddPlugin registers a plugin and builds it into the store. It is a
+// file/manifest operation: clone + compile + content-address, then record
+// the resolved ref/hash. It does NOT load the plugin into this process —
+// that happens per job, at dispatch. Building is slow, so it runs
+// asynchronously; the returned record is status loading.
+func (s *Supervisor) AddPlugin(req server.PluginRequest) (server.PluginInfo, error) {
+	if req.Name == "" || req.Source == "" {
+		return server.PluginInfo{}, server.ErrInvalidPlugin
+	}
+
+	s.pmu.Lock()
+	if _, ok := s.pByName[req.Name]; ok {
+		s.pmu.Unlock()
+		return server.PluginInfo{}, server.ErrPluginExists
+	}
+	e := &pluginEntry{
+		name:    req.Name,
+		addedAt: s.now(),
+		source:  req.Source,
+		tag:     req.Tag,
+		status:  server.PluginLoading,
+	}
+	s.pByName[req.Name] = e
+	s.pOrder = append(s.pOrder, req.Name)
+	s.pmu.Unlock()
+
+	go s.buildEntry(e, "")
+	return e.info(), nil
+}
+
+// UpdatePlugin re-points an existing plugin at a new source/tag and rebuilds
+// it into the store. Editing a plugin changes what future jobs can use;
+// pipelines already running keep the plugin snapshot they were dispatched
+// with, so none of them are disturbed. If a previous version of this plugin
+// is already resident in the process, the rebuilt binary can't be
+// hot-swapped (Go can't reload a package) — it lands in the store and the
+// record is flagged RestartRequired, taking effect for new jobs after a
+// restart.
+func (s *Supervisor) UpdatePlugin(name string, req server.PluginRequest) (server.PluginInfo, error) {
+	s.pmu.Lock()
+	e, ok := s.pByName[name]
+	s.pmu.Unlock()
+	if !ok {
+		return server.PluginInfo{}, server.ErrPluginNotFound
+	}
+
+	e.mu.Lock()
+	prevHash := e.hash
+	if req.Source != "" {
+		e.source = req.Source
+	}
+	e.tag = req.Tag
+	e.status = server.PluginLoading
+	e.errMsg = ""
+	e.mu.Unlock()
+
+	go s.buildEntry(e, prevHash)
+	return e.info(), nil
+}
+
+// RemovePlugin deregisters a plugin from the manifest, so new jobs can no
+// longer declare it. It does not touch running pipelines (they hold their
+// own snapshot), the content-addressed binary in the store (a cache), or any
+// copy already resident in this process (Go can't unload it).
+func (s *Supervisor) RemovePlugin(name string) (server.PluginInfo, error) {
+	s.pmu.Lock()
+	defer s.pmu.Unlock()
+	e, ok := s.pByName[name]
+	if !ok {
+		return server.PluginInfo{}, server.ErrPluginNotFound
+	}
+	delete(s.pByName, name)
+	for i, n := range s.pOrder {
+		if n == name {
+			s.pOrder = append(s.pOrder[:i], s.pOrder[i+1:]...)
+			break
+		}
+	}
+	return e.info(), nil
+}
+
+// buildEntry fetches and compiles a plugin into the store, then records the
+// resolved ref/hash. prevHash is the entry's hash before an update (empty on
+// a first add) — used to flag RestartRequired when the old version was
+// already resident.
+func (s *Supervisor) buildEntry(e *pluginEntry, prevHash string) {
+	e.mu.Lock()
+	spec := parse.Plugin{Name: e.name, Source: e.source, Tag: e.tag}
+	e.mu.Unlock()
+
+	ref, hash, err := s.buildPlugin(spec)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if err != nil {
+		e.status = server.PluginFailed
+		e.errMsg = err.Error()
+		return
+	}
+	e.ref, e.hash = ref, hash
+	t := s.now()
+	e.builtAt = &t
+	e.status = server.PluginReady
+	e.errMsg = ""
+	e.restartRequired = false
+	if prevHash != "" && prevHash != hash {
+		s.pmu.Lock()
+		_, opened := s.openedPlugin[prevHash]
+		s.pmu.Unlock()
+		e.restartRequired = opened
+	}
+}
+
+// loadForJob resolves a job's plugin{} specs against the manifest and opens
+// the corresponding binaries from the store, returning stdlib plus the
+// loaded plugins. A spec that isn't registered, isn't built, or doesn't
+// match the manifest is a clear error — a job must declare plugins the
+// instance actually has (mirroring how `psyduck run` needs a lock file).
+func (s *Supervisor) loadForJob(specs []parse.Plugin) ([]sdk.Plugin, error) {
+	out := append([]sdk.Plugin(nil), s.base...)
+	for _, sp := range specs {
+		s.pmu.Lock()
+		e, ok := s.pByName[sp.Name]
+		s.pmu.Unlock()
+		if !ok {
+			return nil, fmt.Errorf("plugin %q is not registered on this instance; POST /api/v1/plugins to add it", sp.Name)
+		}
+
+		e.mu.Lock()
+		st, src, ref, hash, tag := e.status, e.source, e.ref, e.hash, e.tag
+		e.mu.Unlock()
+		if st != server.PluginReady {
+			return nil, fmt.Errorf("plugin %q is not ready (status: %s)", sp.Name, st)
+		}
+		if sp.Source != "" && sp.Source != src {
+			return nil, fmt.Errorf("plugin %q source %q does not match the registered %q", sp.Name, sp.Source, src)
+		}
+		if sp.Tag != "" && sp.Tag != tag {
+			return nil, fmt.Errorf("plugin %q tag %q does not match the registered %q", sp.Name, sp.Tag, tag)
+		}
+
+		p, err := s.openCached(sp.Name, src, ref, hash)
+		if err != nil {
+			return nil, fmt.Errorf("loading plugin %q: %w", sp.Name, err)
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// openCached opens a plugin binary from the store, memoized by content hash.
+// The first open makes that binary resident for the life of the process
+// (Go plugins can't be unloaded); every later request for the same hash
+// reuses it — which also means a job re-declaring an already-loaded plugin
+// version costs nothing.
+func (s *Supervisor) openCached(name, source, ref, hash string) (sdk.Plugin, error) {
+	s.pmu.Lock()
+	if p, ok := s.openedPlugin[hash]; ok {
+		s.pmu.Unlock()
+		return p, nil
+	}
+	s.pmu.Unlock()
+
+	p, err := s.openPlugin(parse.Plugin{Name: name, Source: source}, ref, hash)
+	if err != nil {
+		return nil, err
+	}
+
+	s.pmu.Lock()
+	s.openedPlugin[hash] = p
+	s.pmu.Unlock()
+	return p, nil
+}
+
+// manifestResources projects a loaded plugin's resource descriptors into the
+// API manifest shape.
+func manifestResources(p sdk.Plugin) []server.PluginResource {
+	descs := p.Resources()
+	out := make([]server.PluginResource, 0, len(descs))
+	for _, d := range descs {
+		r := server.PluginResource{Name: d.Name, Kinds: kindStrings(d.Kinds)}
+		for _, sp := range d.Spec {
+			r.Options = append(r.Options, optionOf(sp))
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// kindStrings renders a sdk.Kind bitmask as the verb forms the rest of the
+// API uses ("produce"/"transform"/"consume").
+func kindStrings(k sdk.Kind) []string {
+	var out []string
+	if k&sdk.PRODUCER != 0 {
+		out = append(out, "produce")
+	}
+	if k&sdk.TRANSFORMER != 0 {
+		out = append(out, "transform")
+	}
+	if k&sdk.CONSUMER != 0 {
+		out = append(out, "consume")
+	}
+	return out
+}
+
+// optionOf projects one sdk.Spec (recursively, for list/map elements and
+// object fields) into a PluginOption.
+func optionOf(sp *sdk.Spec) server.PluginOption {
+	o := server.PluginOption{
+		Name:        sp.Name,
+		Type:        sp.Type.String(),
+		Description: sp.Description,
+		Required:    sp.Required,
+		Default:     sp.Default,
+	}
+	if sp.ElemType != nil {
+		e := optionOf(sp.ElemType)
+		o.Elem = &e
+	}
+	for _, f := range sp.Fields {
+		o.Fields = append(o.Fields, optionOf(f))
+	}
+	return o
+}

--- a/supervise/plugins_test.go
+++ b/supervise/plugins_test.go
@@ -1,0 +1,233 @@
+package supervise
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/psyduck-etl/sdk"
+
+	"github.com/gastrodon/psyduck/parse"
+	"github.com/gastrodon/psyduck/server"
+)
+
+// fakePlugin is a working in-proc plugin offering a single "emit" producer,
+// so a dispatched job can actually load and run it without cloning or CGO.
+func fakePlugin(name string) sdk.Plugin {
+	return sdk.NewInProc(name, &sdk.Resource{
+		Name:  "emit",
+		Kinds: sdk.PRODUCER,
+		Spec: []*sdk.Spec{
+			{Name: "times", Description: "how many to emit", Type: sdk.TypeInt, Default: 1},
+		},
+		ProvideProducer: func(p sdk.Parser) (sdk.Producer, error) {
+			cfg := struct {
+				Times int `psy:"times"`
+			}{}
+			if err := p(&cfg); err != nil {
+				return nil, err
+			}
+			return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
+				defer close(send)
+				defer close(errs)
+				for i := 0; i < cfg.Times; i++ {
+					select {
+					case send <- []byte("x"):
+					case <-ctx.Done():
+						return
+					}
+				}
+			}, nil
+		},
+	})
+}
+
+// pluginTestSupervisor is a supervisor whose build/open steps are faked:
+// build derives a deterministic ref/hash (and fails for a "boom" source),
+// open returns a fakePlugin. No git, no go build, no plugin.Open.
+func pluginTestSupervisor(t *testing.T) *Supervisor {
+	t.Helper()
+	s := newSupervisor(context.Background(), fixedClock(), t.TempDir())
+	s.buildPlugin = func(spec parse.Plugin) (string, string, error) {
+		if strings.Contains(spec.Source, "boom") {
+			return "", "", fmt.Errorf("build blew up")
+		}
+		return "refs/tags/" + orDefault(spec.Tag, "v0"), "hash-" + spec.Name + "-" + spec.Tag, nil
+	}
+	s.openPlugin = func(spec parse.Plugin, ref, hash string) (sdk.Plugin, error) {
+		return fakePlugin(spec.Name), nil
+	}
+	return s
+}
+
+func orDefault(v, d string) string {
+	if v == "" {
+		return d
+	}
+	return v
+}
+
+func waitPlugin(t *testing.T, s *Supervisor, name string, want server.PluginStatus) server.PluginInfo {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, p := range s.Plugins() {
+			if p.Name == name && p.Status == want {
+				return p
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("plugin %s never reached %q; have %+v", name, want, s.Plugins())
+	return server.PluginInfo{}
+}
+
+func TestPluginLifecycle(t *testing.T) {
+	s := pluginTestSupervisor(t)
+
+	added, err := s.AddPlugin(server.PluginRequest{Name: "fake", Source: "file:///fake", Tag: "v1"})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if added.Status != server.PluginLoading {
+		t.Errorf("add status: got %q, want loading", added.Status)
+	}
+
+	ready := waitPlugin(t, s, "fake", server.PluginReady)
+	if ready.Hash == "" || ready.Ref == "" {
+		t.Errorf("ready plugin missing ref/hash: %+v", ready)
+	}
+
+	// Manifest introspection opens the plugin and reports its resources.
+	man, ok := s.Plugin("fake")
+	if !ok {
+		t.Fatal("manifest missing")
+	}
+	if len(man.Resources) != 1 || man.Resources[0].Name != "emit" {
+		t.Fatalf("manifest resources: %+v", man.Resources)
+	}
+	if got := man.Resources[0].Kinds; len(got) != 1 || got[0] != "produce" {
+		t.Errorf("kinds: %v", got)
+	}
+	if len(man.Resources[0].Options) != 1 || man.Resources[0].Options[0].Name != "times" {
+		t.Errorf("options: %+v", man.Resources[0].Options)
+	}
+
+	// Update re-points it; still ready afterward.
+	if _, err := s.UpdatePlugin("fake", server.PluginRequest{Source: "file:///fake", Tag: "v2"}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	upd := waitPlugin(t, s, "fake", server.PluginReady)
+	if upd.Tag != "v2" {
+		t.Errorf("update tag: got %q, want v2", upd.Tag)
+	}
+
+	// Remove deregisters it.
+	if _, err := s.RemovePlugin("fake"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if len(s.Plugins()) != 0 {
+		t.Errorf("plugins after remove: %+v", s.Plugins())
+	}
+	if _, ok := s.Plugin("fake"); ok {
+		t.Error("manifest still present after remove")
+	}
+}
+
+func TestAddPluginValidation(t *testing.T) {
+	s := pluginTestSupervisor(t)
+	if _, err := s.AddPlugin(server.PluginRequest{Name: "x"}); err != server.ErrInvalidPlugin {
+		t.Errorf("missing source: got %v", err)
+	}
+	if _, err := s.AddPlugin(server.PluginRequest{Name: "fake", Source: "file:///fake"}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := s.AddPlugin(server.PluginRequest{Name: "fake", Source: "file:///fake"}); err != server.ErrPluginExists {
+		t.Errorf("duplicate: got %v, want ErrPluginExists", err)
+	}
+}
+
+func TestAddPluginBuildFailure(t *testing.T) {
+	s := pluginTestSupervisor(t)
+	if _, err := s.AddPlugin(server.PluginRequest{Name: "bad", Source: "file:///boom"}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	failed := waitPlugin(t, s, "bad", server.PluginFailed)
+	if failed.Error == "" {
+		t.Error("failed plugin has no error message")
+	}
+}
+
+func TestUpdateRemoveUnknown(t *testing.T) {
+	s := pluginTestSupervisor(t)
+	if _, err := s.UpdatePlugin("nope", server.PluginRequest{Source: "x"}); err != server.ErrPluginNotFound {
+		t.Errorf("update unknown: got %v", err)
+	}
+	if _, err := s.RemovePlugin("nope"); err != server.ErrPluginNotFound {
+		t.Errorf("remove unknown: got %v", err)
+	}
+}
+
+const jobWithPlugin = `
+plugin "fake" {
+  source = "file:///fake"
+}
+
+produce "emit" "e" {
+  times = 4
+}
+
+consume "trash" "t" {}
+
+pipeline "uses-plugin" {
+  produce = [produce.emit.e]
+  consume = [consume.trash.t]
+}
+`
+
+// TestDispatchLoadsRegisteredPlugin proves the per-job loading model: a
+// dispatched job that declares a plugin{} block runs against the plugin the
+// instance has in its manifest.
+func TestDispatchLoadsRegisteredPlugin(t *testing.T) {
+	s := pluginTestSupervisor(t)
+	if _, err := s.AddPlugin(server.PluginRequest{Name: "fake", Source: "file:///fake"}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	waitPlugin(t, s, "fake", server.PluginReady)
+
+	created, err := s.Dispatch(server.DispatchRequest{Source: jobWithPlugin})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	done := waitStatus(t, s, created.ID, server.StatusSucceeded)
+	if done.Stats.Produced != 4 || done.Stats.Delivered != 4 {
+		t.Errorf("stats: %+v, want produced=delivered=4", done.Stats)
+	}
+}
+
+// TestDispatchUnregisteredPluginFails: a job may only declare plugins the
+// instance actually has.
+func TestDispatchUnregisteredPluginFails(t *testing.T) {
+	s := pluginTestSupervisor(t)
+	_, err := s.Dispatch(server.DispatchRequest{Source: jobWithPlugin})
+	if err == nil || !strings.Contains(err.Error(), "not registered") {
+		t.Fatalf("expected a not-registered error, got %v", err)
+	}
+}
+
+// TestDispatchPluginSourceMismatch: the job's plugin block must match the
+// manifest, not just name-match.
+func TestDispatchPluginSourceMismatch(t *testing.T) {
+	s := pluginTestSupervisor(t)
+	if _, err := s.AddPlugin(server.PluginRequest{Name: "fake", Source: "file:///other"}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	waitPlugin(t, s, "fake", server.PluginReady)
+
+	_, err := s.Dispatch(server.DispatchRequest{Source: jobWithPlugin})
+	if err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected a source-mismatch error, got %v", err)
+	}
+}

--- a/supervise/supervise.go
+++ b/supervise/supervise.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gastrodon/psyduck/core"
 	"github.com/gastrodon/psyduck/parse"
 	"github.com/gastrodon/psyduck/parse/hcl"
+	"github.com/gastrodon/psyduck/plugins"
 	"github.com/gastrodon/psyduck/server"
 	"github.com/gastrodon/psyduck/stdlib"
 )
@@ -31,15 +32,17 @@ import (
 // runs every dispatched pipeline under baseCtx, so canceling baseCtx (the
 // serve command's SIGINT/SIGTERM context) winds every pipeline down.
 //
-// Scope note: dispatched pipelines resolve against the plugins handed to New
-// — stdlib by default. A dispatched source that references an external
-// plugin{} fails at build with a clear "no plugin loaded" error, because the
-// clone/compile store flow (psyduck init) isn't part of the serve path yet.
-// That's a documented phase-1 limitation, not a design decision.
+// Plugins: an instance keeps a manifest of plugins (see plugins.go) that
+// operators add/update/remove over the API — a store/file operation that
+// clones and compiles each into the content-addressed store. A dispatched
+// job declares the plugins it needs with plugin{} blocks, exactly like a
+// .psy file for `psyduck run`; at dispatch those blocks are resolved against
+// the manifest and loaded from the store for that job. Editing the manifest
+// changes what future jobs can use and never disturbs a running pipeline.
 type Supervisor struct {
 	id      string
 	baseCtx context.Context
-	plugins []sdk.Plugin
+	base    []sdk.Plugin // always-available plugins (stdlib + any passed to New)
 	now     func() time.Time
 
 	startedAt time.Time
@@ -48,28 +51,73 @@ type Supervisor struct {
 	mu    sync.Mutex
 	byID  map[string]*managed
 	order []string
+
+	// Plugin registry: dynamically loaded plugins available to new
+	// dispatches. store holds the content-addressed binaries; buildPlugin
+	// and openPlugin are the fetch/compile and plugin.Open steps, split so
+	// an update can rebuild-for-restart (build only) without reopening. Both
+	// are injectable for tests.
+	store       *plugins.Store
+	buildPlugin func(spec parse.Plugin) (ref, hash string, err error)
+	openPlugin  func(spec parse.Plugin, ref, hash string) (sdk.Plugin, error)
+
+	pmu     sync.Mutex
+	pByName map[string]*pluginEntry
+	pOrder  []string
+	// openedPlugin caches every plugin binary this process has opened, keyed
+	// by content hash. Go's plugin.Open cannot unload, so an opened plugin
+	// stays here for the life of the process; the cache lets repeated jobs
+	// reuse it and lets an update detect that a prior version is resident.
+	openedPlugin map[string]sdk.Plugin
 }
 
 var _ server.Supervisor = (*Supervisor)(nil)
 
 // New builds a live supervisor. baseCtx bounds every pipeline it runs;
-// plugins are the resource plugins dispatched pipelines may use (stdlib is
-// always included, so passing none is fine).
-func New(baseCtx context.Context, plugins ...sdk.Plugin) *Supervisor {
-	return newSupervisor(baseCtx, time.Now, plugins...)
+// storeRoot is the directory (e.g. ".psyduck") where dynamically added
+// plugins are cloned, built, and content-addressed; base are always-present
+// plugins dispatched pipelines may use (stdlib is always included, so
+// passing none is fine).
+func New(baseCtx context.Context, storeRoot string, base ...sdk.Plugin) *Supervisor {
+	return newSupervisor(baseCtx, time.Now, storeRoot, base...)
 }
 
 // newSupervisor is the injectable-clock constructor for tests.
-func newSupervisor(baseCtx context.Context, now func() time.Time, plugins ...sdk.Plugin) *Supervisor {
-	loaded := append([]sdk.Plugin{stdlib.Plugin()}, plugins...)
-	return &Supervisor{
-		id:        "psyduck-local",
-		baseCtx:   baseCtx,
-		plugins:   loaded,
-		now:       now,
-		startedAt: now(),
-		byID:      make(map[string]*managed),
+func newSupervisor(baseCtx context.Context, now func() time.Time, storeRoot string, base ...sdk.Plugin) *Supervisor {
+	s := &Supervisor{
+		id:           "psyduck-local",
+		baseCtx:      baseCtx,
+		base:         append([]sdk.Plugin{stdlib.Plugin()}, base...),
+		now:          now,
+		startedAt:    now(),
+		byID:         make(map[string]*managed),
+		store:        plugins.NewStore(storeRoot),
+		pByName:      make(map[string]*pluginEntry),
+		openedPlugin: make(map[string]sdk.Plugin),
 	}
+	// Real fetch/compile/open, backed by the content-addressed store. Tests
+	// override these to avoid cloning and CGO.
+	s.buildPlugin = func(spec parse.Plugin) (string, string, error) {
+		locked, err := s.store.Build([]parse.Plugin{spec})
+		if err != nil {
+			return "", "", err
+		}
+		entry, ok := locked[spec.Name]
+		if !ok {
+			return "", "", fmt.Errorf("build produced no entry for %q", spec.Name)
+		}
+		return entry.Ref, entry.Hash, nil
+	}
+	s.openPlugin = func(spec parse.Plugin, ref, hash string) (sdk.Plugin, error) {
+		loaded, err := s.store.Load(map[string]plugins.LockedPlugin{
+			spec.Name: {Source: spec.Source, Ref: ref, Hash: hash},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return loaded[0], nil
+	}
+	return s
 }
 
 // managed is one supervised pipeline: its immutable identity, its live core
@@ -82,6 +130,11 @@ type managed struct {
 	topology  server.Topology
 	createdAt time.Time
 	cancel    context.CancelFunc
+	// plugins is the set this pipeline was dispatched against (stdlib plus
+	// whatever its plugin{} blocks resolved to). It's captured at dispatch
+	// and used for its build, so plugin edits after dispatch never affect a
+	// running pipeline — only future jobs.
+	plugins []sdk.Plugin
 
 	mu         sync.Mutex
 	status     server.PipelineStatus
@@ -154,7 +207,23 @@ func (s *Supervisor) Dispatch(req server.DispatchRequest) (server.PipelineInfo, 
 	}
 
 	id := fmt.Sprintf("pipe-%06d", s.seq.Add(1))
-	pipe, err := s.parseOne(id, req.Source)
+	entry, loader := s.loaderFor(id, req.Source)
+
+	// The job declares which plugins it needs via plugin{} blocks, exactly
+	// like a .psy file for `psyduck run`. Resolve those against this
+	// instance's manifest and load them from the store (stdlib is always
+	// present). This snapshot is what the pipeline runs against for its whole
+	// life — later plugin edits change future jobs, never this one.
+	jobSpecs, err := hcl.NewParserHCL().Plugins(entry, loader)
+	if err != nil {
+		return server.PipelineInfo{}, fmt.Errorf("reading plugin blocks: %w", err)
+	}
+	loaded, err := s.loadForJob(jobSpecs)
+	if err != nil {
+		return server.PipelineInfo{}, err
+	}
+
+	pipe, err := parsePipeline(s.baseCtx, entry, loader, loaded)
 	if err != nil {
 		return server.PipelineInfo{}, err
 	}
@@ -176,6 +245,7 @@ func (s *Supervisor) Dispatch(req server.DispatchRequest) (server.PipelineInfo, 
 		createdAt: s.now(),
 		cancel:    cancel,
 		status:    server.StatusPending,
+		plugins:   loaded,
 	}
 
 	s.mu.Lock()
@@ -188,21 +258,25 @@ func (s *Supervisor) Dispatch(req server.DispatchRequest) (server.PipelineInfo, 
 	return m.snapshot(), nil
 }
 
-// parseOne parses one dispatched .psy document and requires it to declare
-// exactly one pipeline. The source is fed through an in-memory Loader keyed
-// by a synthetic entry name; imports are rejected (dispatched pipelines must
-// be self-contained).
-func (s *Supervisor) parseOne(id, source string) (parse.Pipeline, error) {
-	entry := "dispatch:" + id
+// loaderFor builds the in-memory entry name and Loader for a dispatched
+// source: the source is served under a synthetic entry name, and imports are
+// rejected (dispatched pipelines must be self-contained). The same loader
+// feeds both plugin-block extraction and the full parse, so they agree.
+func (s *Supervisor) loaderFor(id, source string) (entry string, load parse.Loader) {
+	entry = "dispatch:" + id
 	name := parse.ResolveImportPath("", entry) // Parse resolves the entry the same way
-	loader := func(path string) (parse.Source, error) {
+	return entry, func(path string) (parse.Source, error) {
 		if path == name {
 			return parse.Source{Name: name, Content: []byte(source)}, nil
 		}
 		return parse.Source{}, fmt.Errorf("dispatch %s: cannot import %q; dispatched pipelines must be self-contained", id, path)
 	}
+}
 
-	pipes, err := hcl.NewParserHCL().Parse(s.baseCtx, entry, loader, s.plugins)
+// parsePipeline parses a dispatched source against loaded plugins and
+// requires it to declare exactly one pipeline.
+func parsePipeline(ctx context.Context, entry string, loader parse.Loader, loaded []sdk.Plugin) (parse.Pipeline, error) {
+	pipes, err := hcl.NewParserHCL().Parse(ctx, entry, loader, loaded)
 	if err != nil {
 		return parse.Pipeline{}, fmt.Errorf("parsing dispatched pipeline: %w", err)
 	}
@@ -231,7 +305,7 @@ func (s *Supervisor) run(ctx context.Context, m *managed, pipe parse.Pipeline) {
 	m.startedAt = &started
 	m.mu.Unlock()
 
-	built, err := core.BuildPipeline(ctx, pipe, s.plugins)
+	built, err := core.BuildPipeline(ctx, pipe, m.plugins)
 	if err != nil {
 		s.finish(m, fmt.Errorf("building pipeline: %w", err))
 		return

--- a/supervise/supervise.go
+++ b/supervise/supervise.go
@@ -1,0 +1,349 @@
+// Package supervise is the live [server.Supervisor]: it owns the pipelines a
+// psyduck serve instance is running, parsing dispatched .psy documents,
+// building them with core, running each in its own goroutine, and reporting
+// live status and stats.
+//
+// It sits below the server package in the dependency graph — server defines
+// the HTTP surface and the Supervisor interface and imports neither core nor
+// parse; supervise implements that interface using core, parse, and stdlib.
+// That's the boundary docs/http-api.md describes: the HTTP layer never learns
+// about pipelines, only about the interface.
+package supervise
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/psyduck-etl/sdk"
+
+	"github.com/gastrodon/psyduck/core"
+	"github.com/gastrodon/psyduck/parse"
+	"github.com/gastrodon/psyduck/parse/hcl"
+	"github.com/gastrodon/psyduck/server"
+	"github.com/gastrodon/psyduck/stdlib"
+)
+
+// Supervisor is the in-process, live implementation of server.Supervisor. It
+// runs every dispatched pipeline under baseCtx, so canceling baseCtx (the
+// serve command's SIGINT/SIGTERM context) winds every pipeline down.
+//
+// Scope note: dispatched pipelines resolve against the plugins handed to New
+// — stdlib by default. A dispatched source that references an external
+// plugin{} fails at build with a clear "no plugin loaded" error, because the
+// clone/compile store flow (psyduck init) isn't part of the serve path yet.
+// That's a documented phase-1 limitation, not a design decision.
+type Supervisor struct {
+	id      string
+	baseCtx context.Context
+	plugins []sdk.Plugin
+	now     func() time.Time
+
+	startedAt time.Time
+	seq       atomic.Uint64
+
+	mu    sync.Mutex
+	byID  map[string]*managed
+	order []string
+}
+
+var _ server.Supervisor = (*Supervisor)(nil)
+
+// New builds a live supervisor. baseCtx bounds every pipeline it runs;
+// plugins are the resource plugins dispatched pipelines may use (stdlib is
+// always included, so passing none is fine).
+func New(baseCtx context.Context, plugins ...sdk.Plugin) *Supervisor {
+	return newSupervisor(baseCtx, time.Now, plugins...)
+}
+
+// newSupervisor is the injectable-clock constructor for tests.
+func newSupervisor(baseCtx context.Context, now func() time.Time, plugins ...sdk.Plugin) *Supervisor {
+	loaded := append([]sdk.Plugin{stdlib.Plugin()}, plugins...)
+	return &Supervisor{
+		id:        "psyduck-local",
+		baseCtx:   baseCtx,
+		plugins:   loaded,
+		now:       now,
+		startedAt: now(),
+		byID:      make(map[string]*managed),
+	}
+}
+
+// managed is one supervised pipeline: its immutable identity, its live core
+// stats, and its mutable lifecycle state behind mu.
+type managed struct {
+	id        string
+	name      string
+	source    string
+	labels    map[string]string
+	topology  server.Topology
+	createdAt time.Time
+	cancel    context.CancelFunc
+
+	mu         sync.Mutex
+	status     server.PipelineStatus
+	errMsg     string
+	startedAt  *time.Time
+	finishedAt *time.Time
+	stats      *core.Stats // nil until the pipeline is built
+}
+
+func (s *Supervisor) Instance() server.InstanceInfo {
+	list := s.List()
+	var c server.PipelineCounts
+	for _, p := range list {
+		c.Total++
+		switch p.Status {
+		case server.StatusRunning:
+			c.Running++
+		case server.StatusPending:
+			c.Pending++
+		case server.StatusSucceeded:
+			c.Succeeded++
+		case server.StatusFailed:
+			c.Failed++
+		case server.StatusCanceled:
+			c.Canceled++
+		}
+	}
+	return server.InstanceInfo{
+		ID:            s.id,
+		Version:       server.Version,
+		StartedAt:     s.startedAt,
+		UptimeSeconds: s.now().Sub(s.startedAt).Seconds(),
+		Pipelines:     c,
+	}
+}
+
+func (s *Supervisor) List() []server.PipelineInfo {
+	s.mu.Lock()
+	ms := make([]*managed, 0, len(s.order))
+	for _, id := range s.order {
+		ms = append(ms, s.byID[id])
+	}
+	s.mu.Unlock()
+
+	out := make([]server.PipelineInfo, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m.snapshot())
+	}
+	return out
+}
+
+func (s *Supervisor) Get(id string) (server.PipelineInfo, bool) {
+	s.mu.Lock()
+	m, ok := s.byID[id]
+	s.mu.Unlock()
+	if !ok {
+		return server.PipelineInfo{}, false
+	}
+	return m.snapshot(), true
+}
+
+func (s *Supervisor) Graph() server.Graph { return server.BuildGraph(s.List()) }
+
+// Dispatch parses and validates the request synchronously — so a malformed
+// .psy comes straight back as an error the handler turns into 400 — then
+// runs the pipeline asynchronously and returns its pending record.
+func (s *Supervisor) Dispatch(req server.DispatchRequest) (server.PipelineInfo, error) {
+	if req.Source == "" {
+		return server.PipelineInfo{}, server.ErrInvalidSource
+	}
+
+	id := fmt.Sprintf("pipe-%06d", s.seq.Add(1))
+	pipe, err := s.parseOne(id, req.Source)
+	if err != nil {
+		return server.PipelineInfo{}, err
+	}
+
+	name := req.Name
+	if name == "" {
+		name = pipe.Name
+	}
+
+	// The cancel is created here, before the goroutine starts, so Cancel
+	// always has something to call even if the pipeline is still pending.
+	ctx, cancel := context.WithCancel(s.baseCtx)
+	m := &managed{
+		id:        id,
+		name:      name,
+		source:    "dispatch:" + name,
+		labels:    req.Labels,
+		topology:  topologyOf(pipe.Spec),
+		createdAt: s.now(),
+		cancel:    cancel,
+		status:    server.StatusPending,
+	}
+
+	s.mu.Lock()
+	s.byID[id] = m
+	s.order = append(s.order, id)
+	s.mu.Unlock()
+
+	go s.run(ctx, m, pipe)
+
+	return m.snapshot(), nil
+}
+
+// parseOne parses one dispatched .psy document and requires it to declare
+// exactly one pipeline. The source is fed through an in-memory Loader keyed
+// by a synthetic entry name; imports are rejected (dispatched pipelines must
+// be self-contained).
+func (s *Supervisor) parseOne(id, source string) (parse.Pipeline, error) {
+	entry := "dispatch:" + id
+	name := parse.ResolveImportPath("", entry) // Parse resolves the entry the same way
+	loader := func(path string) (parse.Source, error) {
+		if path == name {
+			return parse.Source{Name: name, Content: []byte(source)}, nil
+		}
+		return parse.Source{}, fmt.Errorf("dispatch %s: cannot import %q; dispatched pipelines must be self-contained", id, path)
+	}
+
+	pipes, err := hcl.NewParserHCL().Parse(s.baseCtx, entry, loader, s.plugins)
+	if err != nil {
+		return parse.Pipeline{}, fmt.Errorf("parsing dispatched pipeline: %w", err)
+	}
+	switch len(pipes) {
+	case 1:
+		for _, p := range pipes {
+			return p, nil
+		}
+	case 0:
+		return parse.Pipeline{}, errors.New("dispatched source declares no pipeline")
+	}
+	return parse.Pipeline{}, fmt.Errorf("dispatched source declares %d pipelines; dispatch exactly one", len(pipes))
+}
+
+// run builds and runs a dispatched pipeline to a terminal state. It is the
+// live counterpart of the CLI run path: build (which may block binding a
+// produce-from seed), then RunPipeline, then record how it ended.
+func (s *Supervisor) run(ctx context.Context, m *managed, pipe parse.Pipeline) {
+	m.mu.Lock()
+	if m.status == server.StatusCanceled { // canceled while pending
+		m.mu.Unlock()
+		return
+	}
+	m.status = server.StatusRunning
+	started := s.now()
+	m.startedAt = &started
+	m.mu.Unlock()
+
+	built, err := core.BuildPipeline(ctx, pipe, s.plugins)
+	if err != nil {
+		s.finish(m, fmt.Errorf("building pipeline: %w", err))
+		return
+	}
+
+	m.mu.Lock()
+	m.stats = built.Stats // now reads see live counters
+	m.mu.Unlock()
+
+	s.finish(m, core.RunPipeline(ctx, built))
+}
+
+// finish records the terminal state, unless Cancel already did. A ctx-driven
+// stop (RunPipeline returns a context error) reads as canceled, not failed.
+func (s *Supervisor) finish(m *managed, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.status == server.StatusCanceled {
+		return
+	}
+	fin := s.now()
+	m.finishedAt = &fin
+	switch {
+	case err == nil:
+		m.status = server.StatusSucceeded
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		m.status = server.StatusCanceled
+	default:
+		m.status = server.StatusFailed
+		m.errMsg = err.Error()
+	}
+}
+
+func (s *Supervisor) Cancel(id string) error {
+	s.mu.Lock()
+	m, ok := s.byID[id]
+	s.mu.Unlock()
+	if !ok {
+		return server.ErrNotFound
+	}
+
+	m.mu.Lock()
+	if m.status != server.StatusRunning && m.status != server.StatusPending {
+		m.mu.Unlock()
+		return server.ErrNotCancelable
+	}
+	m.status = server.StatusCanceled
+	fin := s.now()
+	m.finishedAt = &fin
+	m.mu.Unlock()
+
+	m.cancel()
+	return nil
+}
+
+// snapshot renders the managed pipeline as the API view, reading live
+// counters at the instant of the call.
+func (m *managed) snapshot() server.PipelineInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	info := server.PipelineInfo{
+		ID:         m.id,
+		Name:       m.name,
+		Status:     m.status,
+		Source:     m.source,
+		Labels:     m.labels,
+		Topology:   m.topology,
+		Error:      m.errMsg,
+		CreatedAt:  m.createdAt,
+		StartedAt:  m.startedAt,
+		FinishedAt: m.finishedAt,
+	}
+	if m.stats != nil {
+		snap := m.stats.Snapshot()
+		info.Stats = server.Stats{
+			Produced:    snap.Produced,
+			Transformed: snap.Transformed,
+			Filtered:    snap.Filtered,
+			Delivered:   snap.Delivered,
+			Errors:      snap.Errors,
+			InFlight:    inFlight(snap),
+		}
+	}
+	return info
+}
+
+// inFlight is the coarse lag gauge: produced messages that have neither been
+// delivered nor filtered yet. Clamped at zero — transform-side errors (rare)
+// would otherwise let it read slightly negative.
+func inFlight(s core.StatsSnapshot) int64 {
+	n := int64(s.Produced) - int64(s.Delivered) - int64(s.Filtered)
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+// topologyOf projects a parsed pipeline's declared resources into the API's
+// topology view. Refs only — never evaluated config, which can hold secrets.
+func topologyOf(spec parse.PipelineSpec) server.Topology {
+	t := server.Topology{}
+	for _, r := range spec.Producers {
+		t.Producers = append(t.Producers, server.ResourceRef{Ref: r.Ref, Kind: server.StageProduce})
+	}
+	if spec.RemoteSeed != nil {
+		t.RemoteSeed = &server.ResourceRef{Ref: spec.RemoteSeed.Ref, Kind: server.StageProduce}
+	}
+	for _, r := range spec.Transformers {
+		t.Transformers = append(t.Transformers, server.ResourceRef{Ref: r.Ref, Kind: server.StageTransform})
+	}
+	for _, r := range spec.Consumers {
+		t.Consumers = append(t.Consumers, server.ResourceRef{Ref: r.Ref, Kind: server.StageConsume})
+	}
+	return t
+}

--- a/supervise/supervise_test.go
+++ b/supervise/supervise_test.go
@@ -49,7 +49,7 @@ pipeline "demo" {
 // TestDispatchRunsToCompletion is the end-to-end proof the supervisor is
 // live: a dispatched .psy actually runs through core and its counters move.
 func TestDispatchRunsToCompletion(t *testing.T) {
-	s := newSupervisor(context.Background(), fixedClock())
+	s := newSupervisor(context.Background(), fixedClock(), t.TempDir())
 
 	created, err := s.Dispatch(server.DispatchRequest{Name: "demo", Source: constantToTrash})
 	if err != nil {
@@ -73,7 +73,7 @@ func TestDispatchRunsToCompletion(t *testing.T) {
 }
 
 func TestInstanceCountsReflectRuns(t *testing.T) {
-	s := newSupervisor(context.Background(), fixedClock())
+	s := newSupervisor(context.Background(), fixedClock(), t.TempDir())
 	created, err := s.Dispatch(server.DispatchRequest{Source: constantToTrash})
 	if err != nil {
 		t.Fatalf("dispatch: %v", err)
@@ -90,7 +90,7 @@ func TestInstanceCountsReflectRuns(t *testing.T) {
 }
 
 func TestDispatchRejectsBadHCL(t *testing.T) {
-	s := newSupervisor(context.Background(), fixedClock())
+	s := newSupervisor(context.Background(), fixedClock(), t.TempDir())
 	_, err := s.Dispatch(server.DispatchRequest{Source: `this is not valid hcl {{{`})
 	if err == nil {
 		t.Fatal("expected a parse error for bad HCL")
@@ -98,7 +98,7 @@ func TestDispatchRejectsBadHCL(t *testing.T) {
 }
 
 func TestDispatchRejectsNoPipeline(t *testing.T) {
-	s := newSupervisor(context.Background(), fixedClock())
+	s := newSupervisor(context.Background(), fixedClock(), t.TempDir())
 	_, err := s.Dispatch(server.DispatchRequest{Source: `produce "constant" "c" { value = "x" }`})
 	if err == nil {
 		t.Fatal("expected an error when the source declares no pipeline")
@@ -106,7 +106,7 @@ func TestDispatchRejectsNoPipeline(t *testing.T) {
 }
 
 func TestDispatchRejectsEmptySource(t *testing.T) {
-	s := newSupervisor(context.Background(), fixedClock())
+	s := newSupervisor(context.Background(), fixedClock(), t.TempDir())
 	if _, err := s.Dispatch(server.DispatchRequest{}); err != server.ErrInvalidSource {
 		t.Fatalf("empty source: got %v, want ErrInvalidSource", err)
 	}
@@ -124,7 +124,7 @@ pipeline "loop" {
 `
 
 func TestCancelRunningPipeline(t *testing.T) {
-	s := newSupervisor(context.Background(), fixedClock())
+	s := newSupervisor(context.Background(), fixedClock(), t.TempDir())
 	created, err := s.Dispatch(server.DispatchRequest{Name: "loop", Source: forever})
 	if err != nil {
 		t.Fatalf("dispatch: %v", err)
@@ -146,7 +146,7 @@ func TestCancelRunningPipeline(t *testing.T) {
 }
 
 func TestCancelUnknown(t *testing.T) {
-	s := newSupervisor(context.Background(), fixedClock())
+	s := newSupervisor(context.Background(), fixedClock(), t.TempDir())
 	if err := s.Cancel("nope"); err != server.ErrNotFound {
 		t.Errorf("cancel unknown: got %v, want ErrNotFound", err)
 	}
@@ -155,7 +155,7 @@ func TestCancelUnknown(t *testing.T) {
 // TestServesOverHTTP wires the live supervisor behind the real router and
 // exercises the dispatch→observe flow end to end through the HTTP layer.
 func TestServesOverHTTP(t *testing.T) {
-	s := newSupervisor(context.Background(), fixedClock())
+	s := newSupervisor(context.Background(), fixedClock(), t.TempDir())
 	created, err := s.Dispatch(server.DispatchRequest{Name: "demo", Source: constantToTrash})
 	if err != nil {
 		t.Fatalf("dispatch: %v", err)

--- a/supervise/supervise_test.go
+++ b/supervise/supervise_test.go
@@ -1,0 +1,172 @@
+package supervise
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gastrodon/psyduck/server"
+)
+
+func fixedClock() func() time.Time {
+	t := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	return func() time.Time { return t }
+}
+
+// waitStatus polls until the pipeline reaches want or the deadline passes.
+func waitStatus(t *testing.T, s *Supervisor, id string, want server.PipelineStatus) server.PipelineInfo {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		p, ok := s.Get(id)
+		if !ok {
+			t.Fatalf("pipeline %s vanished", id)
+		}
+		if p.Status == want {
+			return p
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	p, _ := s.Get(id)
+	t.Fatalf("pipeline %s: waited for %q, stuck at %q (%+v)", id, want, p.Status, p)
+	return server.PipelineInfo{}
+}
+
+const constantToTrash = `
+produce "constant" "c" {
+  value      = "hi"
+  stop-after = 3
+}
+
+consume "trash" "t" {}
+
+pipeline "demo" {
+  produce = [produce.constant.c]
+  consume = [consume.trash.t]
+}
+`
+
+// TestDispatchRunsToCompletion is the end-to-end proof the supervisor is
+// live: a dispatched .psy actually runs through core and its counters move.
+func TestDispatchRunsToCompletion(t *testing.T) {
+	s := newSupervisor(context.Background(), fixedClock())
+
+	created, err := s.Dispatch(server.DispatchRequest{Name: "demo", Source: constantToTrash})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("dispatch returned empty id")
+	}
+	// Topology is extracted at parse time, before the run finishes.
+	if len(created.Topology.Producers) != 1 || created.Topology.Producers[0].Ref != "produce.constant.c" {
+		t.Errorf("topology: %+v", created.Topology)
+	}
+
+	done := waitStatus(t, s, created.ID, server.StatusSucceeded)
+	if got := done.Stats; got.Produced != 3 || got.Delivered != 3 || got.Transformed != 3 || got.Filtered != 0 || got.InFlight != 0 {
+		t.Errorf("stats: %+v, want produced=delivered=transformed=3", got)
+	}
+	if done.FinishedAt == nil || done.StartedAt == nil {
+		t.Errorf("timestamps: started=%v finished=%v", done.StartedAt, done.FinishedAt)
+	}
+}
+
+func TestInstanceCountsReflectRuns(t *testing.T) {
+	s := newSupervisor(context.Background(), fixedClock())
+	created, err := s.Dispatch(server.DispatchRequest{Source: constantToTrash})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	waitStatus(t, s, created.ID, server.StatusSucceeded)
+
+	inst := s.Instance()
+	if inst.Pipelines.Total != 1 || inst.Pipelines.Succeeded != 1 {
+		t.Errorf("instance counts: %+v", inst.Pipelines)
+	}
+	if inst.Version != server.Version {
+		t.Errorf("version: %q", inst.Version)
+	}
+}
+
+func TestDispatchRejectsBadHCL(t *testing.T) {
+	s := newSupervisor(context.Background(), fixedClock())
+	_, err := s.Dispatch(server.DispatchRequest{Source: `this is not valid hcl {{{`})
+	if err == nil {
+		t.Fatal("expected a parse error for bad HCL")
+	}
+}
+
+func TestDispatchRejectsNoPipeline(t *testing.T) {
+	s := newSupervisor(context.Background(), fixedClock())
+	_, err := s.Dispatch(server.DispatchRequest{Source: `produce "constant" "c" { value = "x" }`})
+	if err == nil {
+		t.Fatal("expected an error when the source declares no pipeline")
+	}
+}
+
+func TestDispatchRejectsEmptySource(t *testing.T) {
+	s := newSupervisor(context.Background(), fixedClock())
+	if _, err := s.Dispatch(server.DispatchRequest{}); err != server.ErrInvalidSource {
+		t.Fatalf("empty source: got %v, want ErrInvalidSource", err)
+	}
+}
+
+const forever = `
+produce "constant" "c" { value = "x" }
+
+consume "trash" "t" {}
+
+pipeline "loop" {
+  produce = [produce.constant.c]
+  consume = [consume.trash.t]
+}
+`
+
+func TestCancelRunningPipeline(t *testing.T) {
+	s := newSupervisor(context.Background(), fixedClock())
+	created, err := s.Dispatch(server.DispatchRequest{Name: "loop", Source: forever})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	waitStatus(t, s, created.ID, server.StatusRunning)
+
+	if err := s.Cancel(created.ID); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	got := waitStatus(t, s, created.ID, server.StatusCanceled)
+	if got.FinishedAt == nil {
+		t.Error("canceled pipeline has no finished_at")
+	}
+
+	// Canceling a terminal pipeline is a conflict.
+	if err := s.Cancel(created.ID); err != server.ErrNotCancelable {
+		t.Errorf("re-cancel: got %v, want ErrNotCancelable", err)
+	}
+}
+
+func TestCancelUnknown(t *testing.T) {
+	s := newSupervisor(context.Background(), fixedClock())
+	if err := s.Cancel("nope"); err != server.ErrNotFound {
+		t.Errorf("cancel unknown: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestServesOverHTTP wires the live supervisor behind the real router and
+// exercises the dispatch→observe flow end to end through the HTTP layer.
+func TestServesOverHTTP(t *testing.T) {
+	s := newSupervisor(context.Background(), fixedClock())
+	created, err := s.Dispatch(server.DispatchRequest{Name: "demo", Source: constantToTrash})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	waitStatus(t, s, created.ID, server.StatusSucceeded)
+
+	// The graph projection should include the pipeline and its stages.
+	g := server.New(s) // ensure the live supervisor satisfies server.Supervisor
+	_ = g
+	graph := s.Graph()
+	if len(graph.Nodes) == 0 || len(graph.Edges) == 0 {
+		t.Errorf("graph: nodes=%d edges=%d", len(graph.Nodes), len(graph.Edges))
+	}
+}


### PR DESCRIPTION
Implements the psyduck HTTP API, **stage 1 — everything that concerns a single instance**. Peer-to-peer (siblings, job splitting) is deferred to stage 2, reserved but not built.

The API is **live**: `psyduck serve` parses, builds, and runs dispatched `.psy` documents through the real engine and reports their status and stats as they run. Full design in [`docs/http-api.md`](https://github.com/gastrodon/psyduck/blob/claude/psyduck-http-api-01hicf/docs/http-api.md).

Two commits: (1) the design + routed skeleton against a `Supervisor` interface, (2) the live wiring — a `supervise` package that runs pipelines and stats instrumentation in `core`.

## Summary

A new long-running daemon, `psyduck serve --addr :8080`, covering the three single-instance use cases:

- **Observe** — `GET /api/v1/{instance,pipelines,pipelines/{id},pipelines/{id}/stats}`. Live per-pipeline counters (produced / transformed / filtered / delivered / errors) plus a coarse `in_flight` lag gauge. Addresses the observability ask in #18 (item 9).
- **Dispatch** — `POST /api/v1/pipelines` accepts a whole `.psy` document, parses/builds/runs it asynchronously (`202 Accepted` + `Location`); `DELETE .../{id}` cancels. This is the network front door to the existing [meta-pipeline / `produce-from`](https://github.com/gastrodon/psyduck/blob/claude/psyduck-http-api-01hicf/docs/patterns.md) pattern — reuses `parse/hcl` verbatim, no second schema.
- **Metrics** — both, because the audiences differ: JSON stats on the API for a graph board, and a Prometheus/OpenMetrics `GET /metrics` for Grafana. Plus `GET /api/v1/graph`, a node/edge projection.

### How it's wired

```
HTTP router (server) → server.Supervisor (interface) → supervise.Supervisor → core.Build/RunPipeline
```

- **`server`** — routes, JSON/Prometheus marshaling, payload types. Imports neither `core` nor `parse`; talks only to the `Supervisor` interface. That boundary holds even live.
- **`supervise`** (new) — the live `Supervisor`. `Dispatch` parses the source (in-memory loader, exactly one `pipeline{}`), then builds + runs it in a goroutine under a cancelable child of the serve context. `Cancel` cancels it; terminal state/error come from `RunPipeline`; topology is read from the parsed spec at dispatch time.
- **`core` stats** — `core.Stats` is a set of `atomic.Uint64` counters on `core.Pipeline`; `RunPipeline` bumps them at each observable event. Additive: a nil `Stats` means "don't count", so the CLI `run` path is unchanged. The supervisor snapshots per pipeline and computes `in_flight`.

`StubSupervisor` stays as the `server` package's own test fixture — same interface, no runtime.

### Scope / follow-ups (documented, none change a route or payload)

- Dispatched pipelines resolve against **stdlib only**; an external `plugin{}` block needs the `psyduck init` clone/compile flow the serve path doesn't run yet (fails at build with a clear "no plugin loaded" error).
- **No persistence** — terminal pipelines live in memory.
- **No auth** — dispatch runs arbitrary pipeline config; bind `serve` privately and front it with auth before exposing. Called out as an open question, not designed here.
- Stats are **per-pipeline**; per-resource attribution is a follow-up.

### Deferred to stage 2 (peers)

`Peer` type + `GET /api/v1/peers` exist but return `501`. The doc sketches the open questions: discovery, identity/health, job splitting (natural fit: a coordinator fans work out as `.psy` documents over the stage-1 dispatch endpoint), and aggregation/backpressure.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean
- [x] `go test ./...` — full suite green
- [x] `go test -race ./core/... ./server/... ./supervise/...` — the supervisor shares `core.Stats` across goroutines; race-clean
- [x] `supervise` tests assert the real flow: dispatch → run → `succeeded` with `produced == transformed == delivered == 3`, cancel of a running (infinite) pipeline → `canceled`, and bad/empty/no-pipeline input rejected
- [x] Manual: `psyduck serve` + curl — `POST` a `constant → trash` pipeline returns `202 pending`, then `GET .../{id}` shows `succeeded` with `produced=delivered=5`, and `/metrics` reflects the counters; malformed HCL returns `400` with the HCL diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpSS7QGuVBkGVFQjFMj12t