### PR TITLE
flow: cancel inner ctx on cutoff

### DIFF
--- a/stdlib/flow/flow.go
+++ b/stdlib/flow/flow.go
@@ -98,11 +98,11 @@ func Consumer(c sdk.Consumer, perMinute, perSecond, stopAfter int) sdk.Consumer 
 		return c
 	}
 	return func(ctx context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+		inner := make(chan []byte)
+		defer close(inner)
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		inner := make(chan []byte)
 		go c(ctx, inner, errs, done)
-		defer close(inner)
 
 		wait, count := Limiter(perMinute, perSecond), 0
 		for {

--- a/stdlib/flow/flow.go
+++ b/stdlib/flow/flow.go
@@ -41,16 +41,21 @@ func Limiter(perMinute, perSecond int) func() {
 }
 
 // Producer wraps p with rate limiting and a stop-after cutoff. With all limits
-// unset it returns p unchanged. p receives the same ctx as the wrapper — the
-// sdk contract requires it to select on ctx.Done() on its own — and the
-// wrapper's own relay to send also honors ctx, so an abandoned wrapped
-// producer never blocks past cancellation.
+// unset it returns p unchanged. The wrapper derives an inner ctx that is
+// cancelled on any exit path (cutoff, cancellation, inner-close), so p —
+// which the sdk contract requires to select on ctx.Done() — exits promptly
+// at the cutoff rather than parking on a send into the abandoned inner
+// channel until the whole pipeline ends. Live-subscription producers
+// (websocket listeners, long-poll loops) then get their teardown for free
+// from block-level stop-after.
 func Producer(p sdk.Producer, perMinute, perSecond, stopAfter int) sdk.Producer {
 	if perMinute <= 0 && perSecond <= 0 && stopAfter <= 0 {
 		return p
 	}
 	return func(ctx context.Context, send chan<- []byte, errs chan<- error) {
 		defer close(send)
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		inner := make(chan []byte)
 		go p(ctx, inner, errs)
 
@@ -79,8 +84,9 @@ func Producer(p sdk.Producer, perMinute, perSecond, stopAfter int) sdk.Producer 
 }
 
 // Consumer wraps c with rate limiting and a stop-after cutoff. With all limits
-// unset it returns c unchanged. c receives the same ctx as the wrapper, and
-// the wrapper's own relay from recv also honors ctx.
+// unset it returns c unchanged. The wrapper derives an inner ctx that is
+// cancelled on any exit path so c exits promptly at the cutoff even if it
+// was mid-fetch on an external system.
 //
 // At the cutoff (or on cancellation) the wrapper stops receiving and closes
 // the inner stream; c flushes and closes done. The wrapper deliberately does
@@ -92,6 +98,8 @@ func Consumer(c sdk.Consumer, perMinute, perSecond, stopAfter int) sdk.Consumer 
 		return c
 	}
 	return func(ctx context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		inner := make(chan []byte)
 		go c(ctx, inner, errs, done)
 		defer close(inner)

--- a/stdlib/flow/flow_test.go
+++ b/stdlib/flow/flow_test.go
@@ -78,6 +78,42 @@ func TestProducer(t *testing.T) {
 	}
 }
 
+// A live-subscription-shaped producer: it sends until its ctx is
+// cancelled, then reports via done that ctx.Done fired. Without the
+// wrapper cancelling on stop-after, this loop would keep sending until
+// the outer ctx ends.
+func TestProducerCancelsInnerOnStopAfter(t *testing.T) {
+	done := make(chan struct{})
+	live := func(ctx context.Context, send chan<- []byte, _ chan<- error) {
+		defer close(done)
+		defer close(send)
+		for {
+			select {
+			case send <- []byte{0}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+
+	send, errs := make(chan []byte), make(chan error)
+	go Producer(live, 0, 0, 3)(t.Context(), send, errs)
+
+	got := 0
+	for range send {
+		got++
+	}
+	if got != 3 {
+		t.Fatalf("stop-after: delivered %d, want 3", got)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("inner producer never observed ctx cancel after cutoff")
+	}
+}
+
 func TestConsumer(t *testing.T) {
 	run := func(perMinute, stopAfter, feed int) int {
 		count := 0
@@ -119,6 +155,48 @@ func TestConsumer(t *testing.T) {
 	if got := run(0, 3, 10); got != 3 {
 		t.Fatalf("stop-after: want 3, got %d", got)
 	}
+}
+
+// A consumer that would block on a slow external call unless its ctx
+// cancels: it signals ctx observation via ctxCancelled. Without the
+// wrapper cancelling on stop-after, this call would hang past cutoff.
+func TestConsumerCancelsInnerOnStopAfter(t *testing.T) {
+	ctxCancelled := make(chan struct{})
+	consume := func(ctx context.Context, recv <-chan []byte, _ chan<- error, done chan<- struct{}) {
+		defer close(done)
+		for {
+			select {
+			case _, ok := <-recv:
+				if !ok {
+					return
+				}
+			case <-ctx.Done():
+				close(ctxCancelled)
+				return
+			}
+		}
+	}
+
+	recv, errs, done := make(chan []byte), make(chan error), make(chan struct{})
+	go Consumer(consume, 0, 0, 3)(t.Context(), recv, errs, done)
+
+	go func() {
+		defer close(recv)
+		for i := 0; i < 10; i++ {
+			select {
+			case recv <- []byte{byte(i)}:
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-ctxCancelled:
+	case <-time.After(time.Second):
+		t.Fatal("inner consumer never observed ctx cancel after cutoff")
+	}
+	<-done
 }
 
 func TestGates(t *testing.T) {

--- a/stdlib/flow/flow_test.go
+++ b/stdlib/flow/flow_test.go
@@ -157,39 +157,28 @@ func TestConsumer(t *testing.T) {
 	}
 }
 
-// A consumer that would block on a slow external call unless its ctx
-// cancels: it signals ctx observation via ctxCancelled. Without the
-// wrapper cancelling on stop-after, this call would hang past cutoff.
+// A consumer that reads one message then blocks doing simulated external
+// work — the realistic "consumer is mid-fetch when the cutoff hits"
+// scenario. Only ctx.Done can unblock it: without the wrapper cancelling
+// its ctx on cutoff, close(inner) alone doesn't help (the consumer isn't
+// waiting on inner anymore), and the test times out.
 func TestConsumerCancelsInnerOnStopAfter(t *testing.T) {
 	ctxCancelled := make(chan struct{})
 	consume := func(ctx context.Context, recv <-chan []byte, _ chan<- error, done chan<- struct{}) {
 		defer close(done)
-		for {
-			select {
-			case _, ok := <-recv:
-				if !ok {
-					return
-				}
-			case <-ctx.Done():
-				close(ctxCancelled)
-				return
-			}
+		<-recv // accept one message, then park in external work
+		select {
+		case <-ctx.Done():
+			close(ctxCancelled)
+		case <-time.After(2 * time.Second):
 		}
 	}
 
 	recv, errs, done := make(chan []byte), make(chan error), make(chan struct{})
-	go Consumer(consume, 0, 0, 3)(t.Context(), recv, errs, done)
+	go Consumer(consume, 0, 0, 1)(t.Context(), recv, errs, done)
 
-	go func() {
-		defer close(recv)
-		for i := 0; i < 10; i++ {
-			select {
-			case recv <- []byte{byte(i)}:
-			case <-done:
-				return
-			}
-		}
-	}()
+	recv <- []byte{0}
+	close(recv)
 
 	select {
 	case <-ctxCancelled:


### PR DESCRIPTION
## Summary
- `flow.Producer` / `flow.Consumer` derive an inner ctx and cancel it on every exit path, so the wrapped plugin exits promptly at a block-level `stop-after` cutoff instead of parking until the outer pipeline ctx ends.
- The sdk contract already requires plugins to select on `ctx.Done()` alongside their I/O, so no plugin-side change is needed.
- Two regression tests covering live-subscription-shaped producer and consumer that only exit via ctx.Done — both hang without this fix.

## Why
For REST iterators the pre-fix behavior was a parked send in a select (annoying but not visible). For live-subscription producers (e.g. iFunny's `ifunny-chat-listen` websocket, or any long-poll loop) the subscription stayed active well past the cutoff. Plugins had to declare their own resource-local `stop-after` to work around it. With this change, the host-owned block-level cutoff actually reaches into the wrapped producer.

## Test plan
- [x] `go test ./stdlib/flow/...` passes (added tests fail without the ctx-cancel).
- [x] `go test ./...` — full core suite green.

🌴 Built with love in [South Carolina](https://sc.gov/visitors)