### PR TITLE
Adopt sdk.Transformer keep-bool contract

### DIFF
--- a/core/build.go
+++ b/core/build.go
@@ -53,7 +53,7 @@ Join a collection of transformers into a single that applies them in order
 */
 func stackTransform(transformers []sdk.Transformer) sdk.Transformer {
 	if len(transformers) == 0 {
-		return func(data []byte) ([]byte, error) { return data, nil }
+		return func(data []byte) ([]byte, bool, error) { return data, true, nil }
 	}
 
 	if len(transformers) == 1 {
@@ -62,10 +62,10 @@ func stackTransform(transformers []sdk.Transformer) sdk.Transformer {
 
 	tail := len(transformers) - 1
 
-	return func(data []byte) ([]byte, error) {
-		transformed, err := stackTransform(transformers[:tail])(data)
-		if err != nil || transformed == nil {
-			return nil, err
+	return func(data []byte) ([]byte, bool, error) {
+		transformed, keep, err := stackTransform(transformers[:tail])(data)
+		if err != nil || !keep {
+			return nil, false, err
 		}
 
 		return transformers[tail](transformed)

--- a/core/build_test.go
+++ b/core/build_test.go
@@ -50,7 +50,7 @@ func corePlugin(name string, payload []byte, count int, consumed *int, suffix st
 			Name:  "suffix",
 			Kinds: sdk.TRANSFORMER,
 			ProvideTransformer: func(sdk.Parser) (sdk.Transformer, error) {
-				return func(in []byte) ([]byte, error) { return append(in, suffix...), nil }, nil
+				return func(in []byte) ([]byte, bool, error) { return append(in, suffix...), true, nil }, nil
 			},
 		},
 	)
@@ -69,34 +69,34 @@ func testResource(pluginID, resource string, kind sdk.Kind, meta sdk.BlockMeta) 
 
 func Test_stackTransform(t *testing.T) {
 	appendc := func(c byte) sdk.Transformer {
-		return func(in []byte) ([]byte, error) { return append(in, c), nil }
+		return func(in []byte) ([]byte, bool, error) { return append(in, c), true, nil }
 	}
 
 	// empty stack is identity
-	out, err := stackTransform(nil)([]byte("x"))
-	if err != nil || string(out) != "x" {
-		t.Fatalf("empty stack: %q, %v", out, err)
+	out, keep, err := stackTransform(nil)([]byte("x"))
+	if err != nil || !keep || string(out) != "x" {
+		t.Fatalf("empty stack: %q %v %v", out, keep, err)
 	}
 
 	// applied in declaration order
-	out, err = stackTransform([]sdk.Transformer{appendc('a'), appendc('b'), appendc('c')})([]byte("_"))
-	if err != nil || string(out) != "_abc" {
-		t.Fatalf("order: %q, %v", out, err)
+	out, keep, err = stackTransform([]sdk.Transformer{appendc('a'), appendc('b'), appendc('c')})([]byte("_"))
+	if err != nil || !keep || string(out) != "_abc" {
+		t.Fatalf("order: %q %v %v", out, keep, err)
 	}
 
 	// error propagates and halts the stack
-	boom := func([]byte) ([]byte, error) { return nil, fmt.Errorf("boom") }
-	if _, err := stackTransform([]sdk.Transformer{appendc('a'), boom, appendc('c')})([]byte("_")); err == nil || err.Error() != "boom" {
+	boom := func([]byte) ([]byte, bool, error) { return nil, false, fmt.Errorf("boom") }
+	if _, _, err := stackTransform([]sdk.Transformer{appendc('a'), boom, appendc('c')})([]byte("_")); err == nil || err.Error() != "boom" {
 		t.Fatalf("want boom, got %v", err)
 	}
 
-	// nil (filtered) short-circuits later transformers
-	filter := func([]byte) ([]byte, error) { return nil, nil }
+	// false (filtered) short-circuits later transformers
+	filter := func([]byte) ([]byte, bool, error) { return nil, false, nil }
 	called := false
-	spy := func(in []byte) ([]byte, error) { called = true; return in, nil }
-	out, err = stackTransform([]sdk.Transformer{filter, spy})([]byte("_"))
-	if err != nil || out != nil || called {
-		t.Fatalf("filter: out=%q called=%v err=%v", out, called, err)
+	spy := func(in []byte) ([]byte, bool, error) { called = true; return in, true, nil }
+	out, keep, err = stackTransform([]sdk.Transformer{filter, spy})([]byte("_"))
+	if err != nil || keep || out != nil || called {
+		t.Fatalf("filter: out=%q keep=%v called=%v err=%v", out, keep, called, err)
 	}
 }
 

--- a/core/regression_test.go
+++ b/core/regression_test.go
@@ -119,7 +119,7 @@ func Test_LateErrorAfterExitOnError_NoPanic(t *testing.T) {
 	err := panicSafeRun(t, &Pipeline{
 		Producers:   []sdk.Producer{producer},
 		Consumers:   []sdk.Consumer{consumer},
-		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		Transformer: func(msg []byte) ([]byte, bool, error) { return msg, true, nil },
 		ExitOnError: true,
 	})
 	elapsed := time.Since(start)
@@ -148,7 +148,7 @@ func Test_ConsumerStopAfter_NoDeadlock(t *testing.T) {
 	err := panicSafeRun(t, &Pipeline{
 		Producers:   []sdk.Producer{emitN(100, []byte("x"), nil)},
 		Consumers:   []sdk.Consumer{flow.Consumer(countAll(&got), 0, 0, 3)},
-		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		Transformer: func(msg []byte) ([]byte, bool, error) { return msg, true, nil },
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -194,9 +194,14 @@ func Test_NilMessage_DoesNotTruncateStream(t *testing.T) {
 	}
 
 	err := panicSafeRun(t, &Pipeline{
-		Producers:   producers,
-		Consumers:   []sdk.Consumer{consumer},
-		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		Producers: producers,
+		Consumers: []sdk.Consumer{consumer},
+		Transformer: func(msg []byte) ([]byte, bool, error) {
+			if msg == nil {
+				return nil, false, nil // filter out nil
+			}
+			return msg, true, nil
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -232,7 +237,7 @@ func Test_GoroutinesDoNotAccumulateAcrossRuns(t *testing.T) {
 				},
 			},
 			Consumers:   []sdk.Consumer{countAll(&got), countAll(&got)},
-			Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+			Transformer: func(msg []byte) ([]byte, bool, error) { return msg, true, nil },
 		}
 	}
 
@@ -278,7 +283,7 @@ func Test_CtxAwareProducer_LeavesNoGoroutineOnAbandon(t *testing.T) {
 	if err := panicSafeRun(t, &Pipeline{
 		Producers:   []sdk.Producer{blockForever},
 		Consumers:   []sdk.Consumer{countAll(&got)},
-		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		Transformer: func(msg []byte) ([]byte, bool, error) { return msg, true, nil },
 		StopAfter:   3,
 	}); err != nil {
 		t.Fatal(err)
@@ -323,7 +328,7 @@ func Test_ErrorAfterDataClose_IsDelivered(t *testing.T) {
 	err := panicSafeRun(t, &Pipeline{
 		Producers:   []sdk.Producer{producer},
 		Consumers:   []sdk.Consumer{countAll(&got)},
-		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		Transformer: func(msg []byte) ([]byte, bool, error) { return msg, true, nil },
 		ExitOnError: true,
 	})
 	if err == nil || !strings.Contains(err.Error(), "late error after data close") {
@@ -347,7 +352,7 @@ func Test_ContractViolatingProducer_EngineStillReturns(t *testing.T) {
 	if err := panicSafeRun(t, &Pipeline{
 		Producers:   []sdk.Producer{misbehaving},
 		Consumers:   []sdk.Consumer{countAll(&got)},
-		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		Transformer: func(msg []byte) ([]byte, bool, error) { return msg, true, nil },
 		StopAfter:   3,
 	}); err != nil {
 		t.Fatal(err)

--- a/core/regression_test.go
+++ b/core/regression_test.go
@@ -215,6 +215,65 @@ func Test_NilMessage_DoesNotTruncateStream(t *testing.T) {
 	}
 }
 
+// Regression for the #22 design smell: sdk.Transformer used to return only
+// (data, error), so run.go had no choice but to treat a nil result as
+// "filtered out". That collapsed two distinct signals — "drop this item"
+// and "keep this item, its payload happens to be empty bytes" — into one,
+// the same shape of bug as bufio.Scanner's `sep = ""` busy-spin (issue #27):
+// a single return value forced to carry two meanings, ambiguous at the
+// margins. The keep-bool contract added in the sdk splits them apart:
+// (nil, true, nil) is a legitimately empty message; (nil, false, nil) is a
+// drop. This test locks in the distinction so a future refactor that
+// re-collapses "nil result → filter" fails loudly.
+func Test_Transformer_NilBytesWithKeepIsDelivered_NotFiltered(t *testing.T) {
+	// Ten inputs: even-indexed → transformer returns (nil, true, nil), odd →
+	// (nil, false, nil). Under the old contract every one of these would look
+	// like a filter drop; under the new one, exactly five empty messages must
+	// reach the consumer.
+	const n = 10
+
+	var delivered atomic.Int64
+	var nonNilBytes atomic.Int64
+	consumer := func(_ context.Context, recv <-chan []byte, errs chan<- error, done chan<- struct{}) {
+		defer close(done)
+		defer close(errs)
+		for msg := range recv {
+			delivered.Add(1)
+			if msg != nil {
+				nonNilBytes.Add(1)
+			}
+		}
+	}
+
+	err := panicSafeRun(t, &Pipeline{
+		Producers: []sdk.Producer{
+			func(_ context.Context, send chan<- []byte, errs chan<- error) {
+				defer close(send)
+				defer close(errs)
+				for i := 0; i < n; i++ {
+					send <- []byte{byte(i)}
+				}
+			},
+		},
+		Consumers: []sdk.Consumer{consumer},
+		Transformer: func(msg []byte) ([]byte, bool, error) {
+			if msg[0]%2 == 0 {
+				return nil, true, nil // keep, payload is legitimately empty
+			}
+			return nil, false, nil // filter out
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := delivered.Load(); got != n/2 {
+		t.Fatalf("delivered = %d, want %d (nil bytes with keep=true must not be filtered)", got, n/2)
+	}
+	if got := nonNilBytes.Load(); got != 0 {
+		t.Fatalf("delivered %d non-nil messages; the transformer only ever emitted nil bytes", got)
+	}
+}
+
 // Regression for #11/#19: a run the engine completes must release every
 // goroutine it started — the old join machinery leaked a fixed set per run,
 // even fully successful ones, and every failed ExitOnError run leaked its

--- a/core/run.go
+++ b/core/run.go
@@ -49,7 +49,7 @@ func RunPipeline(outer context.Context, pipeline *Pipeline) error {
 
 	transform := pipeline.Transformer
 	if transform == nil {
-		transform = func(msg []byte) ([]byte, error) { return msg, nil }
+		transform = func(msg []byte) ([]byte, bool, error) { return msg, true, nil }
 	}
 
 	consumers := startSink(ctx, pipeline.Consumers, report)
@@ -61,12 +61,12 @@ func RunPipeline(outer context.Context, pipeline *Pipeline) error {
 			continue
 		}
 
-		transformed, err := transform(msg)
+		transformed, keep, err := transform(msg)
 		if err != nil {
 			report(fmt.Errorf("transformer supplied error: %w", err))
 			continue
 		}
-		if transformed == nil {
+		if !keep {
 			continue // filtered out
 		}
 

--- a/core/run_test.go
+++ b/core/run_test.go
@@ -96,11 +96,11 @@ func Test_RunPipeline(t *testing.T) {
 				consumers[i] = countAll(&got[i])
 			}
 
-			transform := func(msg []byte) ([]byte, error) { return msg, nil }
+			transform := func(msg []byte) ([]byte, bool, error) { return msg, true, nil }
 			if tc.delay {
-				transform = func(msg []byte) ([]byte, error) {
+				transform = func(msg []byte) ([]byte, bool, error) {
 					time.Sleep(time.Millisecond)
-					return msg, nil
+					return msg, true, nil
 				}
 			}
 
@@ -139,11 +139,11 @@ func Test_RunPipeline_filtering(t *testing.T) {
 			}
 		}},
 		Consumers: []sdk.Consumer{countAll(&got)},
-		Transformer: func(msg []byte) ([]byte, error) {
+		Transformer: func(msg []byte) ([]byte, bool, error) {
 			if msg[0]%2 == 0 {
-				return nil, nil // filtered
+				return nil, false, nil // filtered
 			}
-			return msg, nil
+			return msg, true, nil
 		},
 	})
 	if err != nil {
@@ -160,7 +160,7 @@ func Test_RunPipeline_stopAfter(t *testing.T) {
 	err := mustRun(t, t.Context(), &Pipeline{
 		Producers:   []sdk.Producer{emitForever([]byte("x"))},
 		Consumers:   []sdk.Consumer{countAll(&got)},
-		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		Transformer: func(msg []byte) ([]byte, bool, error) { return msg, true, nil },
 		StopAfter:   5,
 	})
 	if err != nil {
@@ -183,7 +183,7 @@ func Test_RunPipeline_cancel(t *testing.T) {
 	err := mustRun(t, ctx, &Pipeline{
 		Producers:   []sdk.Producer{emitForever([]byte("x"))},
 		Consumers:   []sdk.Consumer{countAll(&got)},
-		Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+		Transformer: func(msg []byte) ([]byte, bool, error) { return msg, true, nil },
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("want context.Canceled, got %v", err)
@@ -207,7 +207,7 @@ func Test_RunPipeline_errors(t *testing.T) {
 		err := mustRun(t, t.Context(), &Pipeline{
 			Producers:   []sdk.Producer{erroring("producer")},
 			Consumers:   []sdk.Consumer{countAll(&got)},
-			Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+			Transformer: func(msg []byte) ([]byte, bool, error) { return msg, true, nil },
 			ExitOnError: true,
 		})
 		if !errors.Is(err, boom) {
@@ -223,7 +223,7 @@ func Test_RunPipeline_errors(t *testing.T) {
 		err := mustRun(t, t.Context(), &Pipeline{
 			Producers:   []sdk.Producer{erroring("producer")},
 			Consumers:   []sdk.Consumer{countAll(&got)},
-			Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+			Transformer: func(msg []byte) ([]byte, bool, error) { return msg, true, nil },
 		})
 		if err != nil {
 			t.Fatalf("errors are logged, not returned, without exit-on-error: %v", err)
@@ -238,7 +238,7 @@ func Test_RunPipeline_errors(t *testing.T) {
 		err := mustRun(t, t.Context(), &Pipeline{
 			Producers:   []sdk.Producer{emitN(10, []byte("x"), nil)},
 			Consumers:   []sdk.Consumer{countAll(&got)},
-			Transformer: func(msg []byte) ([]byte, error) { return nil, boom },
+			Transformer: func(msg []byte) ([]byte, bool, error) { return nil, false, boom },
 			ExitOnError: true,
 		})
 		if !errors.Is(err, boom) || !strings.Contains(err.Error(), "transformer supplied error") {
@@ -257,7 +257,7 @@ func Test_RunPipeline_errors(t *testing.T) {
 		err := mustRun(t, t.Context(), &Pipeline{
 			Producers:   []sdk.Producer{emitN(10, []byte("x"), nil)},
 			Consumers:   []sdk.Consumer{consume},
-			Transformer: func(msg []byte) ([]byte, error) { return msg, nil },
+			Transformer: func(msg []byte) ([]byte, bool, error) { return msg, true, nil },
 			ExitOnError: true,
 		})
 		if !errors.Is(err, boom) || !strings.Contains(err.Error(), "consumer supplied error") {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -153,7 +153,7 @@ starts pumping data through, it should be a live pipeline stage.
 ```go
 type Producer    func(send chan<- []byte, errs chan<- error)
 type Consumer    func(recv <-chan []byte, errs chan<- error, done chan<- struct{})
-type Transformer func(in []byte) ([]byte, error)
+type Transformer func(in []byte) ([]byte, bool, error)
 ```
 
 **Producer.** Emit bytes on `send`. Close `send` and `errs` when done. If you
@@ -164,12 +164,13 @@ it will not read more. Errors go on `errs` before you stop.
 exit. `done` is the host's cue that draining finished; do not close it early
 or the host will race you.
 
-**Transformer.** One in, one out. If you need to drop a message, return
-`(nil, nil)`. If you need to signal an error, return `(nil, err)` — the host
-decides whether that terminates the pipeline based on the pipeline's
-`exit-on-error`. Transformers may be called concurrently from more than one
-goroutine; guard mutable state (see `stdlib/transform/dev.go`'s `Count` for a
-mutex example).
+**Transformer.** One in, one out. The middle `bool` return is the keep
+flag: return `(data, true, nil)` to pass the item downstream, or
+`(nil, false, nil)` to explicitly filter it out. To signal an error return
+`(nil, false, err)` — the host decides whether that terminates the pipeline
+based on the pipeline's `exit-on-error`. Transformers may be called
+concurrently from more than one goroutine; guard mutable state (see
+`stdlib/transform/dev.go`'s `Count` for a mutex example).
 
 ### `sdk.BlockMeta`
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.13
 require (
 	github.com/hashicorp/hcl/v2 v2.20.1
 	github.com/itchyny/gojq v0.12.19
-	github.com/psyduck-etl/sdk v0.5.2
+	github.com/psyduck-etl/sdk v0.5.3-0.20260710202941-89fdca3cd8a6
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli/v2 v2.27.1
 	github.com/zclconf/go-cty v1.14.4

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/psyduck-etl/sdk v0.5.2 h1:o1Xfmu2cjQG1zz9ec8Snqt7j6W3da1vqAiqJDrvjJ0U=
 github.com/psyduck-etl/sdk v0.5.2/go.mod h1:gwCEsqNNSfP2cWK9zVVirWwYCb/vtOeLXR0eaiJTz3g=
+github.com/psyduck-etl/sdk v0.5.3-0.20260710202941-89fdca3cd8a6 h1:tKmh2ZNc1NPu6c/4iq856CznjfYicnHmL1CNVMcFRoE=
+github.com/psyduck-etl/sdk v0.5.3-0.20260710202941-89fdca3cd8a6/go.mod h1:gwCEsqNNSfP2cWK9zVVirWwYCb/vtOeLXR0eaiJTz3g=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/parse/hcl/hcl_test.go
+++ b/parse/hcl/hcl_test.go
@@ -67,7 +67,7 @@ func testPlugin(name string) sdk.Plugin {
 			Name:  "echo",
 			Kinds: sdk.TRANSFORMER,
 			ProvideTransformer: func(sdk.Parser) (sdk.Transformer, error) {
-				return func(in []byte) ([]byte, error) { return in, nil }, nil
+				return func(in []byte) ([]byte, bool, error) { return in, true, nil }, nil
 			},
 		},
 	)

--- a/plugins/fetch.go
+++ b/plugins/fetch.go
@@ -57,7 +57,7 @@ func (f *fetcher) cleanup() {
 // the build mirrors this binary's own (mostly relevant to `go test -race`).
 func (f *fetcher) build(codePath string, spec parse.Plugin) (string, error) {
 	tmpOut := filepath.Join(f.tmpDir, spec.Name+".so")
-	args := []string{"build", "-C", codePath, "-o", tmpOut, "-buildmode", "plugin"}
+	args := []string{"build", "-C", codePath, "-o", tmpOut, "-buildmode", "plugin", "-buildvcs=false"}
 	if raceEnabled {
 		args = append(args, "-race")
 	}
@@ -87,16 +87,32 @@ func (f *fetcher) clone(spec parse.Plugin) (string, error) {
 // SHA. Called unconditionally for every remote plugin — even one with no
 // `tag` attribute still lands on some real commit, and that's what gets
 // recorded.
+// gitCmd builds a git subprocess targeted at dir, with GIT_* env vars
+// scrubbed so an ambient GIT_DIR/GIT_INDEX_FILE (set e.g. when psyduck
+// is invoked from inside a git hook) can't override -C dir.
+func gitCmd(dir string, args ...string) *exec.Cmd {
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	env := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "GIT_") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	cmd.Env = env
+	return cmd
+}
+
 func resolveRef(cloneDir string) (string, error) {
-	if out, err := exec.Command("git", "-C", cloneDir, "symbolic-ref", "-q", "HEAD").CombinedOutput(); err == nil {
+	if out, err := gitCmd(cloneDir, "symbolic-ref", "-q", "HEAD").CombinedOutput(); err == nil {
 		return strings.TrimSpace(string(out)), nil
 	}
 
-	if out, err := exec.Command("git", "-C", cloneDir, "describe", "--tags", "--exact-match", "HEAD").CombinedOutput(); err == nil {
+	if out, err := gitCmd(cloneDir, "describe", "--tags", "--exact-match", "HEAD").CombinedOutput(); err == nil {
 		return "refs/tags/" + strings.TrimSpace(string(out)), nil
 	}
 
-	out, err := exec.Command("git", "-C", cloneDir, "rev-parse", "HEAD").CombinedOutput()
+	out, err := gitCmd(cloneDir, "rev-parse", "HEAD").CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve HEAD in %s: %w\noutput: %s", cloneDir, err, out)
 	}

--- a/plugins/fetch_test.go
+++ b/plugins/fetch_test.go
@@ -36,10 +36,21 @@ func TestPluginKind(t *testing.T) {
 }
 
 // mustGit runs a git command in dir, failing the test on error and
-// returning trimmed stdout+stderr.
+// returning trimmed stdout+stderr. It scrubs GIT_* env vars so that when
+// the test is invoked from a pre-commit hook the outer commit's exported
+// GIT_DIR/GIT_INDEX_FILE don't leak into these tempdir git calls.
 func mustGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	env := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "GIT_") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}

--- a/stdlib/flow/flow.go
+++ b/stdlib/flow/flow.go
@@ -125,18 +125,18 @@ func Consumer(c sdk.Consumer, perMinute, perSecond, stopAfter int) sdk.Consumer 
 // Wait sleeps a fixed duration before passing each message through.
 func Wait(ms int) sdk.Transformer {
 	d := time.Duration(ms) * time.Millisecond
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		time.Sleep(d)
-		return in, nil
+		return in, true, nil
 	}
 }
 
 // Throttle rate-limits the stream to perSecond messages, blocking as needed.
 func Throttle(perSecond int) sdk.Transformer {
 	wait := Limiter(0, perSecond)
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		wait()
-		return in, nil
+		return in, true, nil
 	}
 }
 
@@ -144,14 +144,14 @@ func Throttle(perSecond int) sdk.Transformer {
 func Head(count int) sdk.Transformer {
 	var mu sync.Mutex
 	seen := 0
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		if seen >= count {
-			return nil, nil
+			return nil, false, nil
 		}
 		seen++
-		return in, nil
+		return in, true, nil
 	}
 }
 
@@ -159,32 +159,32 @@ func Head(count int) sdk.Transformer {
 func Tail(skip int) sdk.Transformer {
 	var mu sync.Mutex
 	seen := 0
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		if seen < skip {
 			seen++
-			return nil, nil
+			return nil, false, nil
 		}
-		return in, nil
+		return in, true, nil
 	}
 }
 
 // Sample keeps one message in every rate (rate <= 1 keeps everything).
 func Sample(rate int) sdk.Transformer {
 	if rate <= 1 {
-		return func(in []byte) ([]byte, error) { return in, nil }
+		return func(in []byte) ([]byte, bool, error) { return in, true, nil }
 	}
 	var mu sync.Mutex
 	n := 0
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		keep := n%rate == 0
 		n++
 		if keep {
-			return in, nil
+			return in, true, nil
 		}
-		return nil, nil
+		return nil, false, nil
 	}
 }

--- a/stdlib/flow/flow_test.go
+++ b/stdlib/flow/flow_test.go
@@ -125,11 +125,11 @@ func TestGates(t *testing.T) {
 	count := func(fn sdk.Transformer, n int) int {
 		passed := 0
 		for i := 0; i < n; i++ {
-			out, err := fn([]byte("x"))
+			out, keep, err := fn([]byte("x"))
 			if err != nil {
 				t.Fatal(err)
 			}
-			if out != nil {
+			if keep && out != nil {
 				passed++
 			}
 		}

--- a/stdlib/transform/codec.go
+++ b/stdlib/transform/codec.go
@@ -22,9 +22,9 @@ func codecTransformer(decode, encode string, onError data.OnError, op func(data.
 		onError = data.Raise
 	}
 
-	fail := func(err error) ([]byte, error) { return nil, onError(err) }
+	fail := func(err error) ([]byte, bool, error) { return nil, false, onError(err) }
 
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		v, err := data.Decode(in, decode)
 		if err != nil {
 			return fail(err)
@@ -34,12 +34,12 @@ func codecTransformer(decode, encode string, onError data.OnError, op func(data.
 			return fail(err)
 		}
 		if out == nil {
-			return nil, nil // op chose to drop
+			return nil, false, nil // op chose to drop
 		}
 		b, err := data.Encode(out, encode)
 		if err != nil {
 			return fail(err)
 		}
-		return b, nil
+		return b, true, nil
 	}
 }

--- a/stdlib/transform/dev.go
+++ b/stdlib/transform/dev.go
@@ -32,19 +32,19 @@ func Assert(parse sdk.Parser) (sdk.Transformer, error) {
 		msg = "assertion failed"
 	}
 
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		v, err := data.Decode(in, "json")
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		got, ok, err := data.EvalJQ(query, v)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if !ok || falsey(got) {
-			return nil, fmt.Errorf("%s: %s", msg, config.Expression)
+			return nil, false, fmt.Errorf("%s: %s", msg, config.Expression)
 		}
-		return in, nil
+		return in, true, nil
 	}, nil
 }
 
@@ -81,13 +81,13 @@ func Count(parse sdk.Parser) (sdk.Transformer, error) {
 	var mu sync.Mutex
 	n := 0
 
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		n++
 		if n%every != 0 {
-			return in, nil
+			return in, true, nil
 		}
-		return []byte(config.Prefix + strconv.Itoa(n)), nil
+		return []byte(config.Prefix + strconv.Itoa(n)), true, nil
 	}, nil
 }

--- a/stdlib/transform/filter.go
+++ b/stdlib/transform/filter.go
@@ -12,7 +12,8 @@ type filterConfig struct {
 }
 
 // Filter passes a message through only when the jq expression returns a truthy
-// value (anything other than false or null). A nil result also drops the message.
+// value (anything other than false or null). A nil result also filters the
+// message out (returns keep=false).
 func Filter(parse sdk.Parser) (sdk.Transformer, error) {
 	config := new(filterConfig)
 	if err := parse(config); err != nil {
@@ -24,21 +25,21 @@ func Filter(parse sdk.Parser) (sdk.Transformer, error) {
 		return nil, fmt.Errorf("filter: parse expression %q: %w", config.Expression, err)
 	}
 
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		v, err := runJQ(query, in)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		switch val := v.(type) {
 		case nil:
-			return nil, nil // drop
+			return nil, false, nil // drop
 		case bool:
 			if !val {
-				return nil, nil // drop
+				return nil, false, nil // drop
 			}
 		}
 
-		return in, nil // pass through original message
+		return in, true, nil // pass through original message
 	}, nil
 }

--- a/stdlib/transform/inspect.go
+++ b/stdlib/transform/inspect.go
@@ -25,8 +25,8 @@ func Inspect(parse sdk.Parser) (sdk.Transformer, error) {
 		out = os.Stderr
 	}
 
-	return func(data []byte) ([]byte, error) {
+	return func(data []byte) ([]byte, bool, error) {
 		fmt.Fprintf(out, "%s%s\n", config.Prefix, data)
-		return data, nil
+		return data, true, nil
 	}, nil
 }

--- a/stdlib/transform/jq.go
+++ b/stdlib/transform/jq.go
@@ -13,8 +13,9 @@ type jqConfig struct {
 }
 
 // Jq applies a jq expression to the message and emits the result.
-// If the expression produces no output, the message is dropped (nil returned).
-// String outputs are emitted as plain bytes; all other types are JSON-encoded.
+// If the expression produces no output, the message is filtered out
+// (returns keep=false). String outputs are emitted as plain bytes; all
+// other types are JSON-encoded.
 func Jq(parse sdk.Parser) (sdk.Transformer, error) {
 	config := new(jqConfig)
 	if err := parse(config); err != nil {
@@ -26,10 +27,10 @@ func Jq(parse sdk.Parser) (sdk.Transformer, error) {
 		return nil, fmt.Errorf("jq: parse expression %q: %w", config.Expression, err)
 	}
 
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		v, err := runJQ(query, in)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		return marshalJQ(v)
@@ -57,13 +58,17 @@ func runJQ(query *gojq.Query, in []byte) (interface{}, error) {
 }
 
 // marshalJQ converts a jq output value back to bytes.
-func marshalJQ(v interface{}) ([]byte, error) {
+func marshalJQ(v interface{}) ([]byte, bool, error) {
 	if v == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 	// Strings are returned as plain bytes (no JSON quoting).
 	if s, ok := v.(string); ok {
-		return []byte(s), nil
+		return []byte(s), true, nil
 	}
-	return json.Marshal(v)
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, false, err
+	}
+	return b, true, nil
 }

--- a/stdlib/transform/keyed.go
+++ b/stdlib/transform/keyed.go
@@ -74,16 +74,16 @@ func Dedupe(parse sdk.Parser) (sdk.Transformer, error) {
 	seen := make(map[string]struct{}, window)
 	ring := make([]string, 0, window)
 
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		key, ok, err := k.key(in)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if !ok {
-			return in, nil
+			return in, true, nil
 		}
 		if _, dup := seen[key]; dup {
-			return nil, nil
+			return nil, false, nil
 		}
 		if len(ring) >= window {
 			delete(seen, ring[0])
@@ -91,7 +91,7 @@ func Dedupe(parse sdk.Parser) (sdk.Transformer, error) {
 		}
 		seen[key] = struct{}{}
 		ring = append(ring, key)
-		return in, nil
+		return in, true, nil
 	}, nil
 }
 
@@ -118,19 +118,19 @@ func Uniq(parse sdk.Parser) (sdk.Transformer, error) {
 	var last string
 	var have bool
 
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		key, ok, err := k.key(in)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if !ok {
-			return in, nil
+			return in, true, nil
 		}
 		if have && key == last {
-			return nil, nil
+			return nil, false, nil
 		}
 		last, have = key, true
-		return in, nil
+		return in, true, nil
 	}, nil
 }
 
@@ -156,17 +156,20 @@ func Batch(parse sdk.Parser) (sdk.Transformer, error) {
 
 	buf := make(data.List, 0, size)
 
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		v, err := data.Decode(in, "json")
 		if err != nil {
 			v = data.Bytes(in)
 		}
 		buf = append(buf, v)
 		if len(buf) < size {
-			return nil, nil
+			return nil, false, nil
 		}
 		b, err := data.Encode(buf, "json")
+		if err != nil {
+			return nil, false, err
+		}
 		buf = make(data.List, 0, size)
-		return b, err
+		return b, true, nil
 	}, nil
 }

--- a/stdlib/transform/text.go
+++ b/stdlib/transform/text.go
@@ -43,8 +43,8 @@ func stringTransformer(decode string, onError data.OnError, op func(string) (dat
 	if onError == nil {
 		onError = data.Raise
 	}
-	fail := func(err error) ([]byte, error) { return nil, onError(err) }
-	return func(in []byte) ([]byte, error) {
+	fail := func(err error) ([]byte, bool, error) { return nil, false, onError(err) }
+	return func(in []byte) ([]byte, bool, error) {
 		s, err := textString(in, decode)
 		if err != nil {
 			return fail(err)
@@ -54,9 +54,9 @@ func stringTransformer(decode string, onError data.OnError, op func(string) (dat
 			return fail(err)
 		}
 		if out == nil {
-			return nil, nil
+			return nil, false, nil
 		}
-		return out.Bytes(), nil
+		return out.Bytes(), true, nil
 	}
 }
 
@@ -107,20 +107,20 @@ func Join(parse sdk.Parser) (sdk.Transformer, error) {
 	if err != nil {
 		return nil, err
 	}
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		v, err := data.Decode(in, "json")
 		if err != nil {
-			return nil, onError(err)
+			return nil, false, onError(err)
 		}
 		list, ok := v.(data.List)
 		if !ok {
-			return nil, onError(fmt.Errorf("join: want a list, got %s", v.Kind()))
+			return nil, false, onError(fmt.Errorf("join: want a list, got %s", v.Kind()))
 		}
 		parts := make([]string, len(list))
 		for i, e := range list {
 			parts[i] = e.String()
 		}
-		return []byte(strings.Join(parts, config.Delimiter)), nil
+		return []byte(strings.Join(parts, config.Delimiter)), true, nil
 	}, nil
 }
 
@@ -283,17 +283,17 @@ func Hash(parse sdk.Parser) (sdk.Transformer, error) {
 		return nil, fmt.Errorf("hash: unknown algorithm %q", config.Algorithm)
 	}
 
-	return func(in []byte) ([]byte, error) {
+	return func(in []byte) ([]byte, bool, error) {
 		h := newHash()
 		h.Write(in)
 		sum := h.Sum(nil)
 		switch config.Output {
 		case "", "hex":
-			return []byte(hex.EncodeToString(sum)), nil
+			return []byte(hex.EncodeToString(sum)), true, nil
 		case "base64":
-			return []byte(base64.StdEncoding.EncodeToString(sum)), nil
+			return []byte(base64.StdEncoding.EncodeToString(sum)), true, nil
 		default:
-			return nil, fmt.Errorf("hash: unknown output %q", config.Output)
+			return nil, false, fmt.Errorf("hash: unknown output %q", config.Output)
 		}
 	}, nil
 }

--- a/stdlib/transform/transform_test.go
+++ b/stdlib/transform/transform_test.go
@@ -37,11 +37,11 @@ func build(t *testing.T, provider func(sdk.Parser) (sdk.Transformer, error), val
 
 func run(t *testing.T, fn sdk.Transformer, in string) (string, bool) {
 	t.Helper()
-	out, err := fn([]byte(in))
+	out, keep, err := fn([]byte(in))
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	if out == nil {
+	if !keep {
 		return "", false
 	}
 	return string(out), true
@@ -178,15 +178,15 @@ func TestTextGarbageOnError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := fn([]byte{0xff, 0xfe}); err == nil {
+	if _, _, err := fn([]byte{0xff, 0xfe}); err == nil {
 		t.Error("expected utf-8 error on garbage with on-error=raise")
 	}
 
 	// on-error=drop swallows it
 	fn, _ = Upper(psyParser(map[string]any{"decode": "utf-8", "on-error": "drop"}))
-	out, err := fn([]byte{0xff, 0xfe})
-	if err != nil || out != nil {
-		t.Errorf("on-error=drop should swallow: out=%q err=%v", out, err)
+	out, keep, err := fn([]byte{0xff, 0xfe})
+	if err != nil || keep || out != nil {
+		t.Errorf("on-error=drop should swallow: out=%q keep=%v err=%v", out, keep, err)
 	}
 }
 
@@ -261,10 +261,10 @@ func TestFlow(t *testing.T) {
 
 func TestAssertCount(t *testing.T) {
 	fn, _ := Assert(psyParser(map[string]any{"expression": ".ok", "message": "not ok"}))
-	if _, err := fn([]byte(`{"ok":true}`)); err != nil {
+	if _, _, err := fn([]byte(`{"ok":true}`)); err != nil {
 		t.Errorf("assert true errored: %v", err)
 	}
-	if _, err := fn([]byte(`{"ok":false}`)); err == nil {
+	if _, _, err := fn([]byte(`{"ok":false}`)); err == nil {
 		t.Error("assert false should error")
 	}
 


### PR DESCRIPTION
sdk.Transformer is now func([]byte) ([]byte, bool, error): the middle bool signals whether the item stays in the stream (true = keep, false = filter out). Replaces the implicit "nil result = drop" convention.

- Pin sdk to v0.5.3-0.20260710202941-89fdca3cd8a6 (upstream main).
- Update core stackTransform and RunPipeline to check the keep bool instead of a nil result.
- Rewrite every stdlib transformer to return an explicit keep flag — Head/Tail/Sample, Dedupe/Uniq/Batch, Filter, Assert, Count, codec and text on-error paths, and the flow gate combinators.
- Update all test transformers to the new signature.
- Refresh docs/plugins.md Transformer signature and drop semantics.

Also fix a longstanding hook-context test issue: plugins/fetch_test.go mustGit and plugins/fetch.go resolveRef now scrub GIT_* env vars, so an ambient GIT_DIR/GIT_INDEX_FILE (present when running under a git hook) doesn't override -C dir and leak into the target dir's git ops. Pass -buildvcs=false to the plugin build so the .so is reproducible and doesn't fail when the source tree has an unusual VCS state.