### PR TITLE
Add -p/--pipeline flag to run for selecting pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes to psyduck since the Go rewrite. Versions
 before v0.1.0 belong to the archived TypeScript prototype and are not covered
 here. Dates are when the work landed on the release commit.
 
+## Unreleased
+
+- `run` accepts `-p`/`--pipeline <name>` (repeatable) to run only the named
+  pipelines from a file instead of every one. Names may be bare or
+  `pipeline.`-prefixed; an unknown name errors, listing what the file
+  declares. No flag preserves the run-everything behavior.
+
 ## v0.13.1 — 2026-07-22
 
 - `dedupe`: `window=0` now means never-evict — keys are deduplicated for the

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ psyduck <command> <file>.psy [args]
 
 | Command | Purpose |
 |---|---|
-| `run <file>` | Build and run every pipeline declared directly in the file (concurrently, if there's more than one). |
+| `run [-p name ...] <file>` | Build and run every pipeline declared directly in the file (concurrently, if there's more than one). `-p`/`--pipeline` narrows the run to the named pipeline; repeat it to run a subset. Flags go before the file argument. |
 | `list [--stat] <file>` | List the file's pipelines by name. `--stat` adds `r<producers> x<transformers> c<consumers>` and an `r` flag when `produce-from` is used. |
 | `show <file> [name ...]` | Print resource references and evaluated config for each pipeline. |
 | `init <file>` | Fetch and compile every `plugin {}` reachable from the file (including through imports), content-address the built binaries into `.psyduck/`, and write `<file>.lock`. Required before `run`/`list`/`show` will work — see [above](#using-an-external-plugin). |

--- a/main.go
+++ b/main.go
@@ -115,10 +115,34 @@ func loadPipelines(ctx *cli.Context) (map[string]parse.Pipeline, []sdk.Plugin, e
 	return pipelines, loaded, nil
 }
 
-// run builds every pipeline{} declared directly in the target file and
-// runs them. Zero pipelines is an error. One runs directly. More than one
-// run concurrently, one goroutine each; run returns the first error seen
-// (if any) once all of them have finished.
+// selectPipelines filters a file's pipelines down to the names given by
+// -p/--pipeline. No names selects everything — the historical "run the
+// whole file" behavior. A name may be written bare ("gate") or with its
+// namespace prefix ("pipeline.gate"); repeats collapse (a pipeline runs at
+// most once). An unknown name errors, listing what the file declares.
+func selectPipelines(pipelines map[string]parse.Pipeline, names []string) (map[string]parse.Pipeline, error) {
+	if len(names) == 0 {
+		return pipelines, nil
+	}
+
+	selected := make(map[string]parse.Pipeline, len(names))
+	for _, name := range names {
+		name = strings.TrimPrefix(name, "pipeline.")
+		pipe, ok := pipelines[name]
+		if !ok {
+			return nil, fmt.Errorf("no pipeline %q; file declares: %s",
+				name, strings.Join(sortedNames(pipelines), ", "))
+		}
+		selected[name] = pipe
+	}
+	return selected, nil
+}
+
+// run builds every pipeline{} declared directly in the target file — or
+// just the ones named by -p/--pipeline — and runs them. Zero pipelines is
+// an error. One runs directly. More than one run concurrently, one
+// goroutine each; run returns the first error seen (if any) once all of
+// them have finished.
 func run(ctx *cli.Context) error {
 	pipelines, loaded, err := loadPipelines(ctx)
 	if err != nil {
@@ -127,6 +151,11 @@ func run(ctx *cli.Context) error {
 
 	if len(pipelines) == 0 {
 		return fmt.Errorf("%s: declares no pipeline", ctx.Args().First())
+	}
+
+	pipelines, err = selectPipelines(pipelines, ctx.StringSlice("pipeline"))
+	if err != nil {
+		return err
 	}
 
 	built := make([]*core.Pipeline, 0, len(pipelines))
@@ -254,10 +283,17 @@ func main() {
 		Commands: []*cli.Command{
 			{
 				Name:      "run",
-				Usage:     "run every pipeline declared in a file",
+				Usage:     "run pipelines declared in a file",
 				Action:    run,
 				Args:      true,
 				ArgsUsage: "pipeline file",
+				Flags: []cli.Flag{
+					&cli.StringSliceFlag{
+						Name:    "pipeline",
+						Aliases: []string{"p"},
+						Usage:   "run only the named pipeline (repeatable); default is every pipeline in the file",
+					},
+				},
 			},
 			{
 				Name:      "list",

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastrodon/psyduck/parse"
+)
+
+func TestSelectPipelines(t *testing.T) {
+	pipelines := map[string]parse.Pipeline{
+		"gate":     {},
+		"snapshot": {},
+		"tags":     {},
+	}
+
+	t.Run("no names selects everything", func(t *testing.T) {
+		got, err := selectPipelines(pipelines, nil)
+		if err != nil {
+			t.Fatalf("selectPipelines: %v", err)
+		}
+		if len(got) != len(pipelines) {
+			t.Fatalf("want %d pipelines, got %d", len(pipelines), len(got))
+		}
+	})
+
+	t.Run("names filter", func(t *testing.T) {
+		got, err := selectPipelines(pipelines, []string{"gate", "tags"})
+		if err != nil {
+			t.Fatalf("selectPipelines: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("want 2 pipelines, got %d", len(got))
+		}
+		for _, name := range []string{"gate", "tags"} {
+			if _, ok := got[name]; !ok {
+				t.Errorf("missing %q", name)
+			}
+		}
+	})
+
+	t.Run("pipeline. prefix is accepted", func(t *testing.T) {
+		got, err := selectPipelines(pipelines, []string{"pipeline.snapshot"})
+		if err != nil {
+			t.Fatalf("selectPipelines: %v", err)
+		}
+		if _, ok := got["snapshot"]; !ok || len(got) != 1 {
+			t.Fatalf("want just snapshot, got %v", got)
+		}
+	})
+
+	t.Run("repeats collapse", func(t *testing.T) {
+		got, err := selectPipelines(pipelines, []string{"gate", "gate", "pipeline.gate"})
+		if err != nil {
+			t.Fatalf("selectPipelines: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("want 1 pipeline, got %d", len(got))
+		}
+	})
+
+	t.Run("unknown name errors, listing declared", func(t *testing.T) {
+		_, err := selectPipelines(pipelines, []string{"nope"})
+		if err == nil {
+			t.Fatal("want error for unknown pipeline")
+		}
+		for _, want := range []string{`"nope"`, "gate", "snapshot", "tags"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q missing %q", err.Error(), want)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- `run` gains `-p`/`--pipeline <name>`, repeatable, to run only the named pipelines from a file instead of every `pipeline{}` it declares
- Names are items in the `pipeline.*` namespace; the prefix is optional (`-p gate` and `-p pipeline.gate` both work), repeats collapse, and an unknown name errors listing what the file declares
- No flag preserves the existing run-everything behavior; flags go before the file argument (per the existing stray-flag guard)

## Test plan
- [x] `go build ./...` && `go test .` (new `TestSelectPipelines` covers default/filter/prefix/repeat/unknown)
- [x] `run -p bogus examples/meta-socket.psy` → `no pipeline "bogus"; file declares: config-gen, scrape`, exit 1
- [x] `run -p config-gen examples/meta-socket.psy` runs only config-gen (its socket dial fails precisely because `scrape` was not started)
- [x] `run -p pipeline.config-gen` binds the same as the bare name