### PR TITLE
Parse-time language foundation: fixed-point locals resolution

### DIFF
--- a/parse/hcl/context.go
+++ b/parse/hcl/context.go
@@ -65,14 +65,29 @@ func objOrEmpty(m map[string]cty.Value) cty.Value {
 	return cty.ObjectVal(m)
 }
 
+// localRef tracks a local declaration: its name, attribute, and whether it's been resolved yet.
+type localRef struct {
+	name string
+	attr *hcl.Attribute
+	val  cty.Value
+	set  bool
+}
+
 // makeLocalsCtx merges all locals {} blocks across sources (duplicate keys
 // error) and returns the eval context exposing local.*, env.*, and
 // imports.* (the resolved import{} closure for this file, built by the
 // caller — see buildImportsValue in import.go).
+//
+// Locals are resolved to a fixed point via iterative evaluation: each pass
+// evaluates unresolved locals against the current set of resolved locals plus
+// env and imports. This allows locals to reference:
+//  - env.* (environment variables)
+//  - imports.* (imported resources and pipelines)
+//  - local.* (other locals, forward and backward references)
 func makeLocalsCtx(blocks []*hcl.Block, env cty.Value, imports cty.Value) (*hcl.EvalContext, error) {
-	envCtx := &hcl.EvalContext{Variables: map[string]cty.Value{nsEnv: env}}
-
-	values := make(map[string]cty.Value)
+	// Collect all local declarations first, checking for duplicates.
+	locals := make(map[string]*localRef)
+	allRefs := []*localRef{}
 	for _, block := range blocks {
 		attrs, diags := block.Body.JustAttributes()
 		if diags.HasErrors() {
@@ -80,16 +95,103 @@ func makeLocalsCtx(blocks []*hcl.Block, env cty.Value, imports cty.Value) (*hcl.
 		}
 
 		for name, attr := range attrs {
-			if _, dup := values[name]; dup {
+			if _, dup := locals[name]; dup {
 				return nil, fmt.Errorf("duplicate local %q at %s", name, attr.Range)
 			}
 
-			v, diags := attr.Expr.Value(envCtx)
+			ref := &localRef{name: name, attr: attr}
+			locals[name] = ref
+			allRefs = append(allRefs, ref)
+		}
+	}
+
+	// If there are no locals, we're done.
+	if len(locals) == 0 {
+		return &hcl.EvalContext{
+			Variables: map[string]cty.Value{
+				nsLocal:   objOrEmpty(make(map[string]cty.Value)),
+				nsEnv:     env,
+				nsImports: imports,
+			},
+		}, nil
+	}
+
+	// Resolve locals to a fixed point by iteratively evaluating unresolved
+	// locals against the current set of resolved locals.
+	for iterations := 0; iterations < len(locals)+1; iterations++ {
+		resolved := make(map[string]cty.Value)
+		for name, ref := range locals {
+			if ref.set {
+				resolved[name] = ref.val
+			}
+		}
+
+		// Build eval context with current resolved locals, env, and imports.
+		evalCtx := &hcl.EvalContext{
+			Variables: map[string]cty.Value{
+				nsLocal:   objOrEmpty(resolved),
+				nsEnv:     env,
+				nsImports: imports,
+			},
+		}
+
+		progressMade := false
+		unresolvedNames := []string{}
+		for _, ref := range allRefs {
+			if ref.set {
+				continue // Already resolved
+			}
+			unresolvedNames = append(unresolvedNames, ref.name)
+
+			v, diags := ref.attr.Expr.Value(evalCtx)
 			if diags.HasErrors() {
+				// Evaluation failed; check if this is due to undefined local refs.
+				// If the error mentions an unknown variable or unsupported attribute
+				// on local/imports objects, skip this local for now—maybe it will
+				// resolve in the next iteration.
+				errMsg := diags.Error()
+				if strings.Contains(errMsg, "Unknown variable") ||
+					strings.Contains(errMsg, "Unsupported attribute") {
+					continue
+				}
+				// Other errors (type mismatches, etc.) are real and should fail immediately.
 				return nil, diags
 			}
-			values[name] = v
+
+			ref.val = v
+			ref.set = true
+			progressMade = true
 		}
+
+		// If all locals are now resolved, we're done.
+		if len(unresolvedNames) == 0 {
+			break
+		}
+
+		if !progressMade {
+			// No progress was made this iteration; we're stuck with a circular dependency.
+			return nil, fmt.Errorf("local resolution: circular dependency or undefined reference in: %v", unresolvedNames)
+		}
+	}
+
+	// Final check: all locals should be resolved now.
+	unresolved := []string{}
+	for _, ref := range allRefs {
+		if !ref.set {
+			unresolved = append(unresolved, ref.name)
+		}
+	}
+	if len(unresolved) > 0 {
+		return nil, fmt.Errorf("local resolution: unable to resolve: %v", unresolved)
+	}
+
+	// Check that all locals were resolved (shouldn't happen if progressMade logic is sound).
+	values := make(map[string]cty.Value)
+	for name, ref := range locals {
+		if !ref.set {
+			return nil, fmt.Errorf("local %q: undefined reference", name)
+		}
+		values[name] = ref.val
 	}
 
 	return &hcl.EvalContext{

--- a/parse/hcl/hcl_test.go
+++ b/parse/hcl/hcl_test.go
@@ -817,3 +817,184 @@ func TestParseProduceParallelZeroStatic(t *testing.T) {
 		t.Fatalf("ProduceParallel: got %d, want 3 (one per producer)", got)
 	}
 }
+
+func TestParseLocalsCompose(t *testing.T) {
+	// Locals can reference other locals within the same file.
+	entry, load := src(`
+	locals {
+		base  = "hello"
+		greet = local.base
+	}
+
+	produce "constant" "v" {
+		value = local.greet
+	}
+
+	consume "trash" "t" {}
+
+	pipeline "main" {
+		produce = [produce.constant.v]
+		consume = [trash.t]
+	}
+	`)
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	producers := drainAll(t, result["main"].Producers)
+	opts := new(constantOpts)
+	if err := producers[0].Block.Decode(opts); err != nil {
+		t.Fatal(err)
+	}
+	if opts.Value != "hello" {
+		t.Fatalf("local composition failed: want %q, got %q", "hello", opts.Value)
+	}
+}
+
+func TestParseLocalsForwardRef(t *testing.T) {
+	// Locals can reference each other even with forward references.
+	entry, load := src(`
+	locals {
+		later  = local.earlier
+		earlier = "value"
+	}
+
+	produce "constant" "v" {
+		value = local.later
+	}
+
+	consume "trash" "t" {}
+
+	pipeline "main" {
+		produce = [produce.constant.v]
+		consume = [trash.t]
+	}
+	`)
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	producers := drainAll(t, result["main"].Producers)
+	opts := new(constantOpts)
+	if err := producers[0].Block.Decode(opts); err != nil {
+		t.Fatal(err)
+	}
+	if opts.Value != "value" {
+		t.Fatalf("forward reference in locals failed: want %q, got %q", "value", opts.Value)
+	}
+}
+
+func TestParseLocalsChain(t *testing.T) {
+	// Locals can form chains of references.
+	entry, load := src(`
+	locals {
+		a = "base"
+		b = local.a
+		c = local.b
+		d = local.c
+	}
+
+	produce "constant" "v" {
+		value = local.d
+	}
+
+	consume "trash" "t" {}
+
+	pipeline "main" {
+		produce = [produce.constant.v]
+		consume = [trash.t]
+	}
+	`)
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	producers := drainAll(t, result["main"].Producers)
+	opts := new(constantOpts)
+	if err := producers[0].Block.Decode(opts); err != nil {
+		t.Fatal(err)
+	}
+	if opts.Value != "base" {
+		t.Fatalf("local chain failed: want %q, got %q", "base", opts.Value)
+	}
+}
+
+func TestParseLocalsWithImports(t *testing.T) {
+	// Locals can reference imports.
+	fs := files{
+		"a.psy": `produce "constant" "p" { value = "from-import" }`,
+		"b.psy": `
+		import {
+			a = "a.psy"
+		}
+		locals {
+			imported_ref = imports.a.produce.constant.p
+		}
+		consume "trash" "t" {}
+		pipeline "main" {
+			produce = [local.imported_ref]
+			consume = [trash.t]
+		}
+		`,
+	}
+	pipelines, err := NewParserHCL().Parse(t.Context(), "b.psy", fs.load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := drainAll(t, pipelines["main"].Producers)
+	if len(got) != 1 {
+		t.Fatalf("want 1 producer via local import ref, got %d", len(got))
+	}
+	opts := new(constantOpts)
+	if err := got[0].Block.Decode(opts); err != nil {
+		t.Fatal(err)
+	}
+	if opts.Value != "from-import" {
+		t.Fatalf("local->import resolution failed: %q", opts.Value)
+	}
+}
+
+func TestParseLocalsCircular(t *testing.T) {
+	// Circular references in locals should error.
+	entry, load := src(`
+	locals {
+		a = local.b
+		b = local.a
+	}
+
+	produce "constant" "p" {}
+	consume "trash" "t" {}
+	pipeline "main" {
+		produce = [produce.constant.p]
+		consume = [trash.t]
+	}
+	`)
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err == nil || !strings.Contains(err.Error(), "circular") {
+		t.Fatalf("want circular dependency error, got: %v", err)
+	}
+}
+
+func TestParseLocalsUndefinedRef(t *testing.T) {
+	// References to undefined locals should error.
+	entry, load := src(`
+	locals {
+		a = local.nonexistent
+	}
+
+	produce "constant" "p" {}
+	consume "trash" "t" {}
+	pipeline "main" {
+		produce = [produce.constant.p]
+		consume = [trash.t]
+	}
+	`)
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err == nil || !strings.Contains(err.Error(), "undefined") {
+		t.Fatalf("want undefined reference error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Vision: Layered Parse-Time Language Surface

The psyduck configuration language is growing in expressive power. This PR lays the foundation for a coherent, layered language surface that progresses from simple locals to complex validators:

**Foundation Layer (this PR):**
- Fixed-point locals resolution enabling locals to reference each other and imports
- Iterative evaluation tolerates forward references and detects circular dependencies
- Separates syntax/evaluation concerns from downstream interpretation

**Layer 1 (future):**
- Built-in and user-defined functions in expression context
- Foundation: locals can now compose with imports, functions would compose with locals

**Layer 2 (future):**
- Input validators: declare constraints on block inputs via functions
- Report multiple diagnostics per parse (warnings, non-fatal errors)
- Enable "strict but helpful" config design

**Layer 3 (future):**
- Richer diagnostics system: accumulate errors/warnings, format-agnostic types
- Early exit vs. best-effort parsing strategies
- Foundation for configuration wizards and interactive validation

## What Changed

- `makeLocalsCtx()` now uses iterative fixed-point evaluation instead of single-pass env-only evaluation
- Locals can reference other locals (forward and backward), and can see imports
- Circular dependencies and undefined references are detected and reported
- Six new tests validate composition, forward refs, chains, imports, circular deps, and undefined refs
- All 70+ existing tests pass

## Design Notes

**Why fixed-point iteration?** Forward references are common in configs (e.g., base template before specialized variant). Iteration avoids topological sorting complexity while staying declarative.

**Why single-pass error accumulation isn't here?** The foundation is now solid enough to add diagnostic accumulation in Layer 1 (functions layer) without disrupting locals resolution. Locals remain fail-fast for clarity.

**Deliberately left open:**
- Diagnostics format (will be part of Layer 1/2 design)
- Function signatures and scoping (requires expression AST analysis)
- Validator syntax and registry (depends on functions working)

This is the mechanical change that unblocks language growth; later layers will add semantic richness.