### PR TITLE
Add host-owned parallel meta attribute on resource blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes to psyduck since the Go rewrite. Versions
 before v0.1.0 belong to the archived TypeScript prototype and are not covered
 here. Dates are when the work landed on the release commit.
 
+## Unreleased
+
+- Resource blocks accept a host-owned `parallel = n` meta attribute on
+  `produce`, `consume`, and `transform`. It materializes n copies of the
+  resource, exactly as if it had been listed n times. Defaults to 1; values
+  below 1 (and fractional values) are rejected, and it is not allowed on a
+  `produce-from` seed.
+
 ## v0.13.1 — 2026-07-22
 
 - `dedupe`: `window=0` now means never-evict — keys are deduplicated for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ here. Dates are when the work landed on the release commit.
 ## Unreleased
 
 - Resource blocks accept a host-owned `parallel = n` meta attribute on
-  `produce`, `consume`, and `transform`. It materializes n copies of the
-  resource, exactly as if it had been listed n times. Defaults to 1; values
-  below 1 (and fractional values) are rejected, and it is not allowed on a
-  `produce-from` seed.
+  `produce`, `consume`, and `transform`, bringing up n instances of the
+  resource. Producer copies feed the pipeline together (their concurrency still
+  bounded by `produce-parallel`); consumer copies each run concurrently and
+  receive every message; transformer copies fan out — they share one input and
+  greedily process incoming messages in parallel, merging their output.
+  Defaults to 1; values below 1 (and fractional values) are rejected, and it is
+  not allowed on a `produce-from` seed.
 
 ## v0.13.1 — 2026-07-22
 

--- a/core/build.go
+++ b/core/build.go
@@ -91,6 +91,90 @@ func composeTransformers(transformers []sdk.Transformer) sdk.Transformer {
 // bindChunk is how many bindings we ask a Bindings stream for at a time.
 const bindChunk = 8
 
+// collectResources drains a resource stream fully into a slice without
+// binding anything. Used for transformers, which need their per-resource
+// Parallel count in hand (to bind each one n times) before any instance is
+// created — unlike drain, which binds one instance per resource as it goes.
+func collectResources(ctx context.Context, stream parse.ResourceFunc) ([]parse.Resource, error) {
+	var out []parse.Resource
+	for {
+		chunk, err := stream(ctx, bindChunk)
+		if err != nil {
+			return nil, err
+		}
+		if len(chunk) == 0 {
+			return out, nil
+		}
+		out = append(out, chunk...)
+	}
+}
+
+// parallelTransformer builds one transform stage from n independently-bound
+// instances of the same resource. Every instance reads from the stage's single
+// input channel, so each incoming message is picked up by whichever copy is
+// free — greedy load-balancing, not duplication — and their outputs merge into
+// the stage's one output. Ordering across the stage is therefore not preserved,
+// which is the cost of the parallelism the source opted into with parallel = n.
+//
+// The transformer contract has each instance close its own out channel on
+// return, so the copies cannot share one: each gets a private sub channel that
+// a forwarder drains into the merged out. The stage owns closing out, once all
+// copies have finished and their forwarders have drained. errs is shared — the
+// contract never closes it, and multiple senders are fine.
+//
+// With a single instance the stage is the plain transformer, no fan-out
+// machinery — the overwhelmingly common non-parallel path stays untouched.
+func parallelTransformer(instances []sdk.Instance, logger *logrus.Logger) sdk.Transformer {
+	closeInstance := func(instance sdk.Instance) {
+		if err := instance.Close(); err != nil {
+			logger.WithError(err).Warn("failed to close transformer instance")
+		}
+	}
+
+	if len(instances) == 1 {
+		instance := instances[0]
+		return func(ctx context.Context, in <-chan []byte, out chan<- []byte, errs chan<- error) {
+			defer closeInstance(instance)
+			instance.Transform(ctx, in, out, errs)
+		}
+	}
+
+	return func(ctx context.Context, in <-chan []byte, out chan<- []byte, errs chan<- error) {
+		defer close(out)
+		var wg sync.WaitGroup
+		for _, instance := range instances {
+			sub := make(chan []byte)
+			wg.Add(2)
+
+			go func(instance sdk.Instance) {
+				defer wg.Done()
+				defer closeInstance(instance)
+				instance.Transform(ctx, in, sub, errs)
+			}(instance)
+
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case msg, ok := <-sub:
+						if !ok {
+							return
+						}
+						select {
+						case out <- msg:
+						case <-ctx.Done():
+							return
+						}
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+		}
+		wg.Wait()
+	}
+}
+
 // drain exhausts a Bindings stream, binding each against its owning plugin
 // and handing the configured instance to collect. Draining can do real work
 // (produce-from runs its seed) so it is bounded by ctx.
@@ -167,18 +251,30 @@ func BuildPipeline(ctx context.Context, src parse.Pipeline, plugins []sdk.Plugin
 		return nil, fmt.Errorf("%s: pipeline %q has no consumers", src.Origin, src.Name)
 	}
 
-	transformers := make([]sdk.Transformer, 0)
-	if err := drain(ctx, src.Transformers, lookup, func(b parse.Resource, instance sdk.Instance) {
-		transformers = append(transformers, func(ctx context.Context, in <-chan []byte, out chan<- []byte, errs chan<- error) {
-			defer func() {
-				if err := instance.Close(); err != nil {
-					logger.WithError(err).Warn("failed to close transformer instance")
-				}
-			}()
-			instance.Transform(ctx, in, out, errs)
-		})
-	}); err != nil {
+	// Transformers are bound eagerly, one stage per declared resource. A
+	// resource with Parallel > 1 is bound that many times and its instances
+	// fanned out (see parallelTransformer), so the copies process incoming
+	// messages greedily in parallel rather than being chained.
+	transResources, err := collectResources(ctx, src.Transformers)
+	if err != nil {
 		return nil, err
+	}
+	transformers := make([]sdk.Transformer, 0, len(transResources))
+	for _, b := range transResources {
+		plugin, ok := lookup[b.PluginID]
+		if !ok {
+			return nil, fmt.Errorf("%s: %s: no plugin %q loaded", b.Block.Origin(), b.Ref, b.PluginID)
+		}
+		n := max(b.Parallel, 1)
+		instances := make([]sdk.Instance, 0, n)
+		for range n {
+			instance, err := plugin.Bind(ctx, b.Kind, b.Resource.Name, b.Block)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %s: %w", b.Block.Origin(), b.Ref, err)
+			}
+			instances = append(instances, instance)
+		}
+		transformers = append(transformers, parallelTransformer(instances, logger))
 	}
 
 	return &Pipeline{

--- a/core/build_test.go
+++ b/core/build_test.go
@@ -241,6 +241,101 @@ func Test_composeTransformers_ContinuesAfterError(t *testing.T) {
 	}
 }
 
+// fakeInstance is a minimal sdk.Instance whose Transform runs a supplied
+// function and whose Close bumps a counter — enough to exercise
+// parallelTransformer without standing up a real plugin.
+type fakeInstance struct {
+	transform func(context.Context, <-chan []byte, chan<- []byte, chan<- error)
+	closes    *int32
+}
+
+func (fakeInstance) Kind() sdk.Kind                                                        { return sdk.TRANSFORMER }
+func (fakeInstance) Produce(context.Context, chan<- []byte, chan<- error)                  {}
+func (fakeInstance) Consume(context.Context, <-chan []byte, chan<- error, chan<- struct{}) {}
+func (f fakeInstance) Transform(ctx context.Context, in <-chan []byte, out chan<- []byte, errs chan<- error) {
+	f.transform(ctx, in, out, errs)
+}
+func (f fakeInstance) Close() error { atomic.AddInt32(f.closes, 1); return nil }
+
+// A fanned-out stage load-balances its input: every message is handled by
+// exactly one copy, so the output count equals the input count (not input ×
+// copies — that would be duplication). Every instance is also closed.
+func Test_parallelTransformer_NoDuplication(t *testing.T) {
+	passthrough := func(ctx context.Context, in <-chan []byte, out chan<- []byte, errs chan<- error) {
+		defer close(out)
+		for {
+			select {
+			case msg, ok := <-in:
+				if !ok {
+					return
+				}
+				select {
+				case out <- msg:
+				case <-ctx.Done():
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+
+	const n = 4
+	var closes int32
+	instances := make([]sdk.Instance, n)
+	for i := range instances {
+		instances[i] = fakeInstance{transform: passthrough, closes: &closes}
+	}
+
+	inputs := make([][]byte, 30)
+	for i := range inputs {
+		inputs[i] = []byte{byte(i)}
+	}
+	got, _ := runComposed(t, parallelTransformer(instances, pipelineLogger()), inputs...)
+	if len(got) != len(inputs) {
+		t.Fatalf("fan-out must handle each message once: want %d outputs, got %d", len(inputs), len(got))
+	}
+	if closes != n {
+		t.Fatalf("want all %d instances closed, got %d", n, closes)
+	}
+}
+
+// The copies genuinely run at once. Each copy blocks on a shared barrier after
+// taking one message; with exactly n messages the barrier only ever releases
+// if all n copies are in-flight together. A serialized stage would deadlock
+// here — caught by runComposed's timeout.
+func Test_parallelTransformer_RunsConcurrently(t *testing.T) {
+	const n = 3
+	var arrived int32
+	barrier := make(chan struct{})
+	mk := func(tag byte) func(context.Context, <-chan []byte, chan<- []byte, chan<- error) {
+		return func(ctx context.Context, in <-chan []byte, out chan<- []byte, errs chan<- error) {
+			defer close(out)
+			for msg := range in {
+				if atomic.AddInt32(&arrived, 1) == n {
+					close(barrier) // the last copy to arrive frees them all
+				}
+				<-barrier
+				out <- append(append([]byte{}, msg...), tag)
+			}
+		}
+	}
+
+	var closes int32
+	instances := make([]sdk.Instance, n)
+	for i := range instances {
+		instances[i] = fakeInstance{transform: mk(byte('0' + i)), closes: &closes}
+	}
+
+	got, _ := runComposed(t, parallelTransformer(instances, pipelineLogger()), []byte("a"), []byte("b"), []byte("c"))
+	if len(got) != n {
+		t.Fatalf("want %d outputs, got %d", n, len(got))
+	}
+	if closes != n {
+		t.Fatalf("want all %d instances closed, got %d", n, closes)
+	}
+}
+
 func Test_drain(t *testing.T) {
 	consumed := 0
 	plugin := corePlugin("p", []byte("m"), 2, &consumed, "!")

--- a/docs/hcl.md
+++ b/docs/hcl.md
@@ -73,12 +73,23 @@ accepted only on the verbs where it means something:
 producer-only flow governor, and declaring either on a verb that doesn't
 offer it is a parse error, same as any other unknown attribute.
 
-`parallel = n` stamps out n literal copies of the block, exactly as if you had
-listed the resource n times. What that buys you depends on the verb: n
-producers fan into the pipeline together, n consumers each receive every
-message, and n transformers are chained (the transform runs n times in
-series). It is rejected on a `produce-from` seed — a seed is one live stream,
-not a fixed set to duplicate; widen derived concurrency with `produce-parallel`
+`parallel = n` brings up n instances of the resource. What that buys you
+depends on the verb:
+
+- **producers**: n copies feed the pipeline together. How many actually run at
+  once is still governed by `produce-parallel` (the producer worker pool) — a
+  producer `parallel` only enlarges the set of producers, it does not by itself
+  raise concurrency. With the default `produce-parallel = 1` the copies run one
+  at a time.
+- **consumers**: n copies each run concurrently, and each receives *every*
+  message (the sink broadcasts).
+- **transformers**: n copies run concurrently and *share* the input — each
+  incoming message is handled by whichever copy is free (greedy fan-out, not
+  duplication), and their outputs merge back into one stream. Message ordering
+  through the stage is not preserved, which is the trade for the parallelism.
+
+It is rejected on a `produce-from` seed — a seed is one live stream, not a
+fixed set to duplicate; widen derived concurrency with `produce-parallel`
 instead.
 
 Declaring the same `(verb, resource, name)` triple twice in the same file is

--- a/docs/hcl.md
+++ b/docs/hcl.md
@@ -60,17 +60,26 @@ attribute is an error, missing required attributes are errors, and every
 value is evaluated and type-checked at parse time. Expressions may use
 `local.*` and `env.*`.
 
-Two **meta attributes** are host-owned (a plugin never declares them), each
+**Meta attributes** are host-owned (a plugin never declares them), each
 accepted only on the verbs where it means something:
 
 | Attribute | Type | Meaning | Accepted on |
 |---|---|---|---|
 | `stop-after` | int | stop this producer after n items (0 = unrestricted) | `produce` only |
 | `per-minute` | int | rate limit, items per minute (0 = unrestricted) | `produce`, `consume` |
+| `parallel` | int | duplicate this resource n times (default 1, must be ≥ 1) | `produce`, `consume`, `transform` |
 
-`transform` blocks accept neither — a transformer's throughput is bounded by
-its producers and consumers, not itself — and declaring either there is a
-parse error, same as any other unknown attribute.
+`stop-after` and `per-minute` are verb-restricted: `stop-after` is a
+producer-only flow governor, and declaring either on a verb that doesn't
+offer it is a parse error, same as any other unknown attribute.
+
+`parallel = n` stamps out n literal copies of the block, exactly as if you had
+listed the resource n times. What that buys you depends on the verb: n
+producers fan into the pipeline together, n consumers each receive every
+message, and n transformers are chained (the transform runs n times in
+series). It is rejected on a `produce-from` seed — a seed is one live stream,
+not a fixed set to duplicate; widen derived concurrency with `produce-parallel`
+instead.
 
 Declaring the same `(verb, resource, name)` triple twice in the same file is
 an error.

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -254,6 +254,8 @@ when they express what you mean — they're free at the resource site:
 
 - On `produce` blocks: `stop-after = N` (host-owned, producer-only).
 - On `produce`/`consume` blocks: `per-minute = N` (host-owned rate limit).
+- On any `produce`/`consume`/`transform` block: `parallel = N` (host-owned;
+  materializes N copies of the resource).
 - As transformers: `head`, `tail`, `sample`, `throttle`, `wait`.
 
 Rule of thumb: use `stop-after` to bound *sources*, `per-minute` to bound

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -142,17 +142,20 @@ Naming convention: use kebab-case in `Spec.Name` and match it in the `psy`
 struct tag on the config type (`psy:"stop-after"`). This is consistent with
 the rest of the ecosystem and with what users type in `.psy`.
 
-Two attribute names are **reserved**: `stop-after` and `per-minute`. The host
-strips these off the block before your `Parser` runs (they become the
-resource's `sdk.BlockMeta`), and it enforces both behaviors independently of
-the plugin. Do not declare them in your `Spec`, and do not try to read them
-from your config struct — they will not be there.
+Three attribute names are **reserved**: `stop-after`, `per-minute`, and
+`parallel`. The host strips these off the block before your `Parser` runs and
+enforces them independently of the plugin. Do not declare them in your `Spec`,
+and do not try to read them from your config struct — they will not be there.
+(`stop-after` and `per-minute` become the resource's `sdk.BlockMeta`;
+`parallel` is core-only and never crosses to the plugin at all — the host
+simply materializes the resource that many times.)
 
-Both are verb-restricted: `stop-after` is accepted only on `produce`
-resources (it's a producer-only flow governor); `per-minute` is accepted on
-`produce` and `consume` resources. Declaring either on a `transform` block,
-or `stop-after` on a `consume` block, is a parse-time error — the host
-rejects it as an unknown attribute before your plugin is ever bound.
+`stop-after` and `per-minute` are verb-restricted: `stop-after` is accepted
+only on `produce` resources (it's a producer-only flow governor); `per-minute`
+is accepted on `produce` and `consume` resources. `parallel` is accepted on
+all three verbs. Declaring `stop-after`/`per-minute` on a verb that doesn't
+offer it is a parse-time error — the host rejects it as an unknown attribute
+before your plugin is ever bound.
 
 ### `sdk.Provider[T]`
 

--- a/parse/hcl/block.go
+++ b/parse/hcl/block.go
@@ -196,18 +196,24 @@ func defaultVal(spec *sdk.Spec, want cty.Type) (cty.Value, error) {
 var (
 	perMinuteSpec = &sdk.Spec{Name: "per-minute", Description: "rate limit: items per minute (0 = unrestricted)", Type: sdk.TypeInt, Default: 0}
 	stopAfterSpec = &sdk.Spec{Name: "stop-after", Description: "stop after n items (0 = unrestricted)", Type: sdk.TypeInt, Default: 0}
+	parallelSpec  = &sdk.Spec{Name: "parallel", Description: "duplicate this resource n times (default 1, must be >= 1)", Type: sdk.TypeInt, Default: 1}
 )
 
-// metaSpecs drives which host-owned attributes (sdk.BlockMeta) a block's
-// source may set, keyed by verb. Plugins never declare these. stop-after is
-// a producer-only flow governor — accepting it on consume or transform would
-// silently do nothing (nothing wraps a transformer, and a consumer's own
-// completion is its own to decide), so those verbs simply don't offer it.
-// per-minute paces both producers and consumers.
+// metaSpecs drives which host-owned attributes a block's source may set,
+// keyed by verb. Plugins never declare these. stop-after is a producer-only
+// flow governor — accepting it on consume or transform would silently do
+// nothing (nothing wraps a transformer, and a consumer's own completion is
+// its own to decide), so those verbs simply don't offer it. per-minute paces
+// both producers and consumers. parallel is accepted on every verb: it just
+// stamps out copies of the block, which is meaningful for any kind. Note
+// that per-minute and stop-after belong to sdk.BlockMeta (decoded via
+// blockMetaSpec), while parallel is core-only (decoded straight into
+// parse.Resource.Parallel by makeBinding) — so it is deliberately absent from
+// blockMetaSpec.
 var metaSpecs = map[string][]*sdk.Spec{
-	blockProduce:   {perMinuteSpec, stopAfterSpec},
-	blockConsume:   {perMinuteSpec},
-	blockTransform: {},
+	blockProduce:   {perMinuteSpec, stopAfterSpec, parallelSpec},
+	blockConsume:   {perMinuteSpec, parallelSpec},
+	blockTransform: {parallelSpec},
 }
 
 // blockMetaSpec is the full sdk.BlockMeta shape, independent of verb. Every

--- a/parse/hcl/hcl_test.go
+++ b/parse/hcl/hcl_test.go
@@ -795,6 +795,185 @@ func TestParseProduceParallelFractional(t *testing.T) {
 	}
 }
 
+// parallel = n on a resource block stamps out n literal copies of it into
+// the pipeline list — one producer written parallel = 3 drains as three.
+func TestParseParallelDuplicatesProducers(t *testing.T) {
+	entry, load := src(`
+	produce "constant" "p" {
+		value    = "x"
+		parallel = 3
+	}
+	consume "trash" "t" {}
+	pipeline "main" {
+		produce = [produce.constant.p]
+		consume = [trash.t]
+	}
+	`)
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	producers := drainAll(t, result["main"].Producers)
+	if len(producers) != 3 {
+		t.Fatalf("want 3 producers from parallel = 3, got %d", len(producers))
+	}
+	for i, p := range producers {
+		if p.Ref != "produce.constant.p" {
+			t.Fatalf("copy %d: bad ref %q", i, p.Ref)
+		}
+	}
+	if got := result["main"].Spec.Producers; len(got) != 3 {
+		t.Fatalf("Spec.Producers: want 3, got %d", len(got))
+	}
+}
+
+// parallel works the same on consumers and transformers — the parser expands
+// their literal lists before core ever sees them.
+func TestParseParallelDuplicatesConsumersAndTransformers(t *testing.T) {
+	entry, load := src(`
+	produce "constant" "p" { value = "x" }
+	consume "trash" "t" { parallel = 2 }
+	transform "echo" "x" { parallel = 4 }
+	pipeline "main" {
+		produce   = [produce.constant.p]
+		transform = [transform.echo.x]
+		consume   = [trash.t]
+	}
+	`)
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := drainAll(t, result["main"].Consumers); len(got) != 2 {
+		t.Fatalf("want 2 consumers from parallel = 2, got %d", len(got))
+	}
+	if got := drainAll(t, result["main"].Transformers); len(got) != 4 {
+		t.Fatalf("want 4 transformers from parallel = 4, got %d", len(got))
+	}
+}
+
+// Absent, parallel defaults to 1: one copy, exactly as before the field
+// existed.
+func TestParseParallelAbsent(t *testing.T) {
+	entry, load := src(`
+	produce "constant" "p" { value = "x" }
+	consume "trash" "t" {}
+	pipeline "main" {
+		produce = [produce.constant.p]
+		consume = [trash.t]
+	}
+	`)
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := drainAll(t, result["main"].Producers); len(got) != 1 {
+		t.Fatalf("default parallel: want 1 producer, got %d", len(got))
+	}
+}
+
+// parallel is a duplication count, so 0 is meaningless and rejected — mirrors
+// the "must be >= 1" contract the field promises.
+func TestParseParallelZeroRejected(t *testing.T) {
+	entry, load := src(`
+	produce "constant" "p" {
+		value    = "x"
+		parallel = 0
+	}
+	consume "trash" "t" {}
+	pipeline "main" {
+		produce = [produce.constant.p]
+		consume = [trash.t]
+	}
+	`)
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err == nil || !strings.Contains(err.Error(), "parallel: must be >= 1") {
+		t.Fatalf("want parallel >= 1 rejection, got: %v", err)
+	}
+}
+
+func TestParseParallelNegativeRejected(t *testing.T) {
+	entry, load := src(`
+	produce "constant" "p" {
+		value    = "x"
+		parallel = -2
+	}
+	consume "trash" "t" {}
+	pipeline "main" {
+		produce = [produce.constant.p]
+		consume = [trash.t]
+	}
+	`)
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err == nil || !strings.Contains(err.Error(), "parallel: must be >= 1") {
+		t.Fatalf("want parallel >= 1 rejection, got: %v", err)
+	}
+}
+
+// A fractional parallel is rejected rather than truncated, following the
+// strict-schema philosophy the rest of the parser holds to.
+func TestParseParallelFractionalRejected(t *testing.T) {
+	entry, load := src(`
+	produce "constant" "p" {
+		value    = "x"
+		parallel = 2.5
+	}
+	consume "trash" "t" {}
+	pipeline "main" {
+		produce = [produce.constant.p]
+		consume = [trash.t]
+	}
+	`)
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err == nil || !strings.Contains(err.Error(), "parallel: must be a whole number") {
+		t.Fatalf("want fractional parallel rejection, got: %v", err)
+	}
+}
+
+// parallel on a produce-from seed is rejected: a seed is one live stream, not
+// something duplication has a sensible meaning for.
+func TestParseParallelProduceFromSeedRejected(t *testing.T) {
+	entry, load := src(`
+	produce "constant" "seed" {
+		value    = "x"
+		parallel = 2
+	}
+	consume "trash" "t" {}
+	pipeline "main" {
+		produce-from = produce.constant.seed
+		consume      = [trash.t]
+	}
+	`)
+	_, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err == nil || !strings.Contains(err.Error(), "parallel is not supported on a produce-from seed") {
+		t.Fatalf("want produce-from seed rejection, got: %v", err)
+	}
+}
+
+// parallel and produce-parallel compose: expansion happens first, so
+// produce-parallel = 0 ("all at once") counts the duplicated producers.
+func TestParseParallelWithProduceParallelZero(t *testing.T) {
+	entry, load := src(`
+	produce "constant" "p" {
+		value    = "x"
+		parallel = 4
+	}
+	consume "trash" "t" {}
+	pipeline "main" {
+		produce          = [produce.constant.p]
+		consume          = [trash.t]
+		produce-parallel = 0
+	}
+	`)
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := result["main"].ProduceParallel; got != 4 {
+		t.Fatalf("ProduceParallel: want 4 (one per expanded producer), got %d", got)
+	}
+}
+
 // With a static produce list, produce-parallel = 0 means "run them all at
 // once" — it resolves to the number of producers declared.
 func TestParseProduceParallelZeroStatic(t *testing.T) {

--- a/parse/hcl/hcl_test.go
+++ b/parse/hcl/hcl_test.go
@@ -829,10 +829,32 @@ func TestParseParallelDuplicatesProducers(t *testing.T) {
 
 // parallel works the same on consumers and transformers — the parser expands
 // their literal lists before core ever sees them.
-func TestParseParallelDuplicatesConsumersAndTransformers(t *testing.T) {
+func TestParseParallelDuplicatesConsumers(t *testing.T) {
 	entry, load := src(`
 	produce "constant" "p" { value = "x" }
 	consume "trash" "t" { parallel = 2 }
+	pipeline "main" {
+		produce = [produce.constant.p]
+		consume = [trash.t]
+	}
+	`)
+	result, err := NewParserHCL().Parse(t.Context(), entry, load, []sdk.Plugin{testPlugin("test")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := drainAll(t, result["main"].Consumers); len(got) != 2 {
+		t.Fatalf("want 2 consumers from parallel = 2, got %d", len(got))
+	}
+}
+
+// Transformers are NOT expanded in the parser: the resource stays single and
+// carries its Parallel count, which core turns into a fan-out stage. Chaining
+// duplicate copies (what expansion would do) would serialize the transform
+// instead of parallelizing it.
+func TestParseParallelTransformerKeptSingle(t *testing.T) {
+	entry, load := src(`
+	produce "constant" "p" { value = "x" }
+	consume "trash" "t" {}
 	transform "echo" "x" { parallel = 4 }
 	pipeline "main" {
 		produce   = [produce.constant.p]
@@ -844,11 +866,12 @@ func TestParseParallelDuplicatesConsumersAndTransformers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := drainAll(t, result["main"].Consumers); len(got) != 2 {
-		t.Fatalf("want 2 consumers from parallel = 2, got %d", len(got))
+	got := drainAll(t, result["main"].Transformers)
+	if len(got) != 1 {
+		t.Fatalf("want the transformer kept as 1 resource, got %d", len(got))
 	}
-	if got := drainAll(t, result["main"].Transformers); len(got) != 4 {
-		t.Fatalf("want 4 transformers from parallel = 4, got %d", len(got))
+	if got[0].Parallel != 4 {
+		t.Fatalf("want transformer Parallel = 4 carried to core, got %d", got[0].Parallel)
 	}
 }
 

--- a/parse/hcl/resource.go
+++ b/parse/hcl/resource.go
@@ -114,6 +114,11 @@ func makeBinding(block *hcl.Block, ix *resourceIndex, localsCtx *hcl.EvalContext
 		return parse.Resource{}, fmt.Errorf("%s %s.%s: %w", block.Type, resRef, name, err)
 	}
 
+	parallel, err := decodeParallel(content.Attributes, localsCtx, origin)
+	if err != nil {
+		return parse.Resource{}, fmt.Errorf("%s %s.%s: %w", block.Type, resRef, name, err)
+	}
+
 	return parse.Resource{
 		Ref:      strings.Join([]string{block.Type, resRef, name}, "."),
 		Kind:     verbKinds[block.Type],
@@ -121,7 +126,36 @@ func makeBinding(block *hcl.Block, ix *resourceIndex, localsCtx *hcl.EvalContext
 		PluginID: pluginID,
 		Block:    &hclBlock{values: specVals, origin: origin},
 		Meta:     meta,
+		Parallel: parallel,
 	}, nil
+}
+
+// decodeParallel reads the core-only `parallel` meta attribute off a resource
+// block. It is not part of sdk.BlockMeta (plugins never see it), so it is
+// evaluated on its own rather than through the BlockMeta decode. Absent, it
+// defaults to 1; present, it must be a whole number >= 1 — the value is a
+// duplication count, so 0 (and any negative) is meaningless and rejected.
+func decodeParallel(attrs hcl.Attributes, ctx *hcl.EvalContext, origin sdk.SourceRange) (int, error) {
+	attr, ok := attrs[parallelSpec.Name]
+	if !ok {
+		return 1, nil
+	}
+	v, diags := attr.Expr.Value(ctx)
+	if diags.HasErrors() {
+		return 0, diags
+	}
+	converted, err := convert.Convert(v, cty.Number)
+	if err != nil {
+		return 0, fmt.Errorf("%s: parallel: expected a whole number: %w", origin, err)
+	}
+	n, acc := converted.AsBigFloat().Int64()
+	if acc != big.Exact {
+		return 0, fmt.Errorf("%s: parallel: must be a whole number", origin)
+	}
+	if n < 1 {
+		return 0, fmt.Errorf("%s: parallel: must be >= 1 (it duplicates the resource that many times); got %d", origin, n)
+	}
+	return int(n), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -160,6 +194,21 @@ func resolveRefs(pipeline string, refs []string, set map[string]parse.Resource) 
 	return resolved, nil
 }
 
+// expandParallel flattens each resource's host-owned parallel count into
+// literal duplicates: a resource with Parallel = n appears n times in a row,
+// exactly as if it had been listed n times. makeBinding guarantees Parallel
+// >= 1, so this only ever grows the list. Downstream (core) sees a plain flat
+// list and never has to know about parallelism.
+func expandParallel(resources []parse.Resource) []parse.Resource {
+	expanded := make([]parse.Resource, 0, len(resources))
+	for _, r := range resources {
+		for range r.Parallel {
+			expanded = append(expanded, r)
+		}
+	}
+	return expanded
+}
+
 func makePipeline(
 	block *hcl.Block,
 	bindings map[string]map[string]parse.Resource,
@@ -186,6 +235,7 @@ func makePipeline(
 	if err != nil {
 		return parse.Pipeline{}, err
 	}
+	consumers = expandParallel(consumers)
 	pipe.Consumers = parse.LiteralResourceFunc(consumers...)
 	pipe.Spec.Consumers = consumers
 
@@ -199,6 +249,7 @@ func makePipeline(
 			return parse.Pipeline{}, err
 		}
 	}
+	transformers = expandParallel(transformers)
 	pipe.Transformers = parse.LiteralResourceFunc(transformers...)
 	pipe.Spec.Transformers = transformers
 
@@ -220,6 +271,7 @@ func makePipeline(
 		if len(producers) == 0 {
 			return parse.Pipeline{}, fmt.Errorf("pipeline %q at %s: at least one producer is required", name, origin)
 		}
+		producers = expandParallel(producers)
 		pipe.Producers = parse.LiteralResourceFunc(producers...)
 		pipe.Spec.Producers = producers
 	case hasRemote:
@@ -230,6 +282,13 @@ func makePipeline(
 		seed, ok := bindings[blockProduce][v.AsString()]
 		if !ok {
 			return parse.Pipeline{}, fmt.Errorf("pipeline %q: unknown produce-from reference %q", name, v.AsString())
+		}
+		if seed.Parallel > 1 {
+			// A produce-from seed is a single live stream that declares its
+			// own producers over time; stamping out duplicate seeds would run
+			// several competing listeners, not "the same producer n times".
+			// Use produce-parallel to widen how many derived producers run.
+			return parse.Pipeline{}, fmt.Errorf("pipeline %q: parallel is not supported on a produce-from seed (%s); use produce-parallel to widen concurrency", name, seed.Ref)
 		}
 		timeout := remoteFirstMessageTimeout
 		if attr, ok := content.Attributes["produce-from-timeout"]; ok {

--- a/parse/hcl/resource.go
+++ b/parse/hcl/resource.go
@@ -197,8 +197,11 @@ func resolveRefs(pipeline string, refs []string, set map[string]parse.Resource) 
 // expandParallel flattens each resource's host-owned parallel count into
 // literal duplicates: a resource with Parallel = n appears n times in a row,
 // exactly as if it had been listed n times. makeBinding guarantees Parallel
-// >= 1, so this only ever grows the list. Downstream (core) sees a plain flat
-// list and never has to know about parallelism.
+// >= 1, so this only ever grows the list. It is used for producers and
+// consumers, whose runtimes already do the right thing with duplicates (the
+// producer pool runs them, the sink fans out to each). Transformers are
+// handled differently — see makePipeline — because chaining duplicate
+// transformers would serialize them instead of running them in parallel.
 func expandParallel(resources []parse.Resource) []parse.Resource {
 	expanded := make([]parse.Resource, 0, len(resources))
 	for _, r := range resources {
@@ -249,7 +252,11 @@ func makePipeline(
 			return parse.Pipeline{}, err
 		}
 	}
-	transformers = expandParallel(transformers)
+	// Transformers are not expanded here the way producers and consumers are:
+	// duplicating a transformer into the flat list would chain the copies (the
+	// transform would run n times in series). Instead each transformer keeps
+	// its Parallel count and core fans it out — n instances greedily sharing
+	// one input — at the transform stage.
 	pipe.Transformers = parse.LiteralResourceFunc(transformers...)
 	pipe.Spec.Transformers = transformers
 

--- a/parse/pipeline.go
+++ b/parse/pipeline.go
@@ -18,6 +18,14 @@ type Resource struct {
 	PluginID string                 // Name() of the owning plugin
 	Block    sdk.ConfigBlock        // the resource's config block; Block.Origin() is where it was defined
 	Meta     sdk.BlockMeta          // pre-decoded host-owned attributes
+	// Parallel is the host-owned duplication count for this resource: the
+	// resource is materialized this many times, exactly as if it had been
+	// written that many times in its pipeline list. It defaults to 1; the
+	// parser rejects anything below 1. It is a core-only meta attribute (not
+	// part of sdk.BlockMeta) — plugins never see it. The parser expands the
+	// duplicates into the pipeline lists, so core runs a plain flat list and
+	// never reads this field.
+	Parallel int
 }
 
 // ResourceFunc yields Resources in chunks of up to max until exhausted.


### PR DESCRIPTION
Adds `parallel = n` to `produce` / `consume` / `transform` blocks — brings up
n instances of the resource. Defaults to 1; `0`, negatives, and fractionals
are rejected at parse time.

For **producers and consumers** it is pure shorthand: `parallel = n` on a ref
is exactly equivalent to listing that ref n times in the pipeline list, with
every copy independent. For **transformers** there is no list-form equivalent
(listing a transformer twice *chains* it, running the transform twice in
series); `parallel = n` instead fans the copies out across one shared input.

## Wiring
- `parse.Resource.Parallel` — core-only, **not** in `sdk.BlockMeta`, so plugins
  never see it (mirrors how `produce-parallel` stays core-side).
- `parallelSpec` registered in `metaSpecs` for all three verbs so the strict
  schema accepts the attribute; decoded separately in `makeBinding`.

## Where the parallelism actually happens
- **producers**: parser `expandParallel` puts n copies in the produce list →
  `producerSource` binds each → the `produce()` worker pool runs them. Actual
  concurrency is bounded by `produce-parallel` (the pool size) — same as if you
  had listed the ref n times.
- **consumers**: parser expands to n copies → `startSink` launches each in its
  own goroutine (genuinely concurrent) → `sink.send` broadcasts every message
  to all of them.
- **transformers**: **not** expanded in the parser (chaining copies would run
  the transform n times in series — that stays available via the list form).
  Instead the resource carries its Parallel count to core, which binds n
  instances and `parallelTransformer` fans them out: all copies share one input
  channel (greedy load-balance, each message handled once), private out
  channels merged downstream. Ordering through the stage is not preserved.

## Not allowed
- On a `produce-from` seed (single live stream, no duplication semantics) —
  rejected with a pointer to `produce-parallel`.

## Tests
- Parser: expansion counts, transformer kept single with Parallel carried,
  default=1, 0/negative/fractional rejection, produce-from-seed rejection,
  `parallel` × `produce-parallel=0`.
- Core: `parallelTransformer` handles each message exactly once (no
  duplication) and closes every instance; a barrier test proves the copies run
  concurrently (a serialized stage would deadlock). Race-clean.

Docs (`hcl.md`, `plugins.md`, `patterns.md`) and CHANGELOG updated.